### PR TITLE
Potential fix for code scanning alert no. 71: Missing rate limiting

### DIFF
--- a/Chapter 06/End of Chapter/webapp/package.json
+++ b/Chapter 06/End of Chapter/webapp/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@types/node": "^20.6.1",
     "bootstrap": "^5.3.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.1.0"
   }
 }

--- a/Chapter 06/End of Chapter/webapp/src/server.ts
+++ b/Chapter 06/End of Chapter/webapp/src/server.ts
@@ -1,8 +1,15 @@
 import { createServer } from "http";
 import express, {Express, Request, Response } from "express";
+import rateLimit from "express-rate-limit";
 import { readHandler } from "./readHandler";
 
 const port = 5000;
+
+
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
 
 const expressApp: Express = express();
 
@@ -10,7 +17,7 @@ expressApp.use(express.json());
 
 expressApp.post("/read", readHandler);
 
-expressApp.get("/sendcity", (req, resp) => {
+expressApp.get("/sendcity", limiter, (req, resp) => {
     resp.sendFile("city.png", { root: "static"});
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/71](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/71)

To address the missing rate limiting vulnerability, a rate limiter middleware (ideally using the well-maintained `express-rate-limit` package) should be applied to the `/sendcity` route. This fix will ensure that requests to this endpoint are restricted to a reasonable rate, preventing abuse. Only the code in `Chapter 06/End of Chapter/webapp/src/server.ts` should be changed; we will:

- Add an import for `express-rate-limit`.
- Define a rate limiter instance (e.g., 100 requests per 15 minutes).
- Apply this rate limiter only to the `/sendcity` route using `expressApp.get("/sendcity", limiter, handler)`.

No changes are needed to the core logic or functionality of the route handler itself.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
