### PR TITLE
Potential fix for code scanning alert no. 66: Reflected cross-site scripting

### DIFF
--- a/Chapter 06/Beginning of Chapter/webapp/package.json
+++ b/Chapter 06/Beginning of Chapter/webapp/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@types/node": "^20.6.1",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "escape-html": "^1.0.3"
   }
 }

--- a/Chapter 06/Beginning of Chapter/webapp/src/handler.ts
+++ b/Chapter 06/Beginning of Chapter/webapp/src/handler.ts
@@ -1,5 +1,6 @@
 import { IncomingMessage, ServerResponse } from "http";
 import { Request, Response } from "express";
+import escapeHtml from "escape-html";
 
 export const redirectionHandler = (req: IncomingMessage, resp: ServerResponse) => {
     resp.writeHead(302, {
@@ -19,7 +20,7 @@ export const newUrlHandler = (req: Request, resp: Response) => {
 
 export const defaultHandler = (req: Request, resp: Response) => {
     if (req.query.keyword) {
-        resp.send(`Hello, ${req.query.keyword}`);                    
+        resp.send(`Hello, ${escapeHtml(req.query.keyword as string)}`);                    
     } else {
         resp.send(`Hello, ${req.protocol.toUpperCase()}`);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/66](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/66)

**General fix:**  
Sanitize or escape any user-supplied data before sending it in an HTTP response. In this context, encode `req.query.keyword` with an HTML escaping function so that any HTML special characters are rendered harmlessly in the browser (e.g., `<` → `&lt;`). This should be done at the point where the interpolation occurs.

**Best way for this code:**  
- Use the well-tested external library `escape-html` (as in the official example) to encode the value before interpolating into the output string.
- Update the relevant import (add `import escapeHtml from 'escape-html'`).
- Replace line 22 to use `escapeHtml(req.query.keyword)`.

**Concrete changes needed:**  
- Add `escape-html` import at the top (if not already present).
- Change line 22 to `resp.send(\`Hello, \${escapeHtml(req.query.keyword as string)}\`);`
- Optionally, also escape values in other similar cases (such as `msg`) if they have the same risk.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
