### PR TITLE
Potential fix for code scanning alert no. 14: Exposure of private files

### DIFF
--- a/Chapter 17/End of Chapter/sportsstore/src/server.ts
+++ b/Chapter 17/End of Chapter/sportsstore/src/server.ts
@@ -16,7 +16,7 @@ expressApp.use(express.json());
 expressApp.use(express.urlencoded({extended: true}))
 
 expressApp.use(express.static("node_modules/bootstrap/dist"));
-expressApp.use(express.static("node_modules/bootstrap-icons"));
+expressApp.use('/icons', express.static("node_modules/bootstrap-icons/icons"));
 
 createTemplates(expressApp);
 createSessions(expressApp);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/14](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/14)

The best way to fix this problem is to only serve the necessary subdirectories or files inside `node_modules/bootstrap-icons` that need to be accessible over HTTP, such as the `font` or `icons` folders. This avoids exposing any metadata or package files (such as `package.json`) or other private content that could be present in the package directory itself. To do this, change the static route from `node_modules/bootstrap-icons` to only the specific directory containing the distributable static assets your application uses, for example `node_modules/bootstrap-icons/font` or `node_modules/bootstrap-icons/icons`. You may also change the route prefix to make it clear in URLs.

**Required actions:**
- Change line 19's `express.static("node_modules/bootstrap-icons")` to `express.static("node_modules/bootstrap-icons/icons")` (or another relevant subdirectory, e.g., `font` if you use font icons).
- Adjust the mount path if you want the icons accessible under a specific subpath (e.g., `/icons`).
- No additional imports or code changes are required, unless you wish to add clarification comments.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
