### PR TITLE
Potential fix for code scanning alert no. 64: Reflected cross-site scripting

### DIFF
--- a/Chapter 05/End of Chapter/webapp/package.json
+++ b/Chapter 05/End of Chapter/webapp/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@types/node": "^20.6.1",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "escape-html": "^1.0.3"
   }
 }

--- a/Chapter 05/End of Chapter/webapp/src/handler.ts
+++ b/Chapter 05/End of Chapter/webapp/src/handler.ts
@@ -1,5 +1,6 @@
 import { IncomingMessage, ServerResponse } from "http";
 import { Request, Response } from "express";
+import escape from "escape-html";
 
 export const redirectionHandler = (req: IncomingMessage, resp: ServerResponse) => {
     resp.writeHead(302, {
@@ -19,7 +20,7 @@ export const newUrlHandler = (req: Request, resp: Response) => {
 
 export const defaultHandler = (req: Request, resp: Response) => {
     if (req.query.keyword) {
-        resp.send(`Hello, ${req.query.keyword}`);                    
+        resp.send(`Hello, ${escape(String(req.query.keyword))}`);                    
     } else {
         resp.send(`Hello, ${req.protocol.toUpperCase()}`);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/64](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/64)

To fix this cross-site scripting issue, the user-supplied value in `req.query.keyword` must be properly escaped before writing it into the response. The standard approach in Node.js/TypeScript is to use a library like `escape-html` to encode unsafe HTML characters, preventing execution of injected scripts when reflected in the browser. This escaping should be applied in exactly the context where the user input is being output to the response body (line 22). Do not otherwise change parameters or application logic. 

The required modifications are:
1. Import the `escape-html` package at the top of `handler.ts`.
2. Wrap the usage of `req.query.keyword` in `escape()` when interpolated into the response.
No other code changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
