### PR TITLE
Potential fix for code scanning alert no. 68: Uncontrolled data used in path expression

### DIFF
--- a/Chapter 10/End of Chapter/part2app/src/server/server.ts
+++ b/Chapter 10/End of Chapter/part2app/src/server/server.ts
@@ -25,8 +25,14 @@ expressApp.use(helmet());
 expressApp.use(express.json());
 
 expressApp.get("/dynamic/:file", (req, resp) => {
-    resp.render(`${req.params.file}.handlebars`, 
-        { message: "Hello template", req, 
+    const fileName = req.params.file;
+    // Allow only safe filenames: letters, numbers, underscores, hyphens
+    if (!/^[A-Za-z0-9_-]+$/.test(fileName)) {
+        resp.status(400).send("Invalid template name");
+        return;
+    }
+    resp.render(`${fileName}.handlebars`,
+        { message: "Hello template", req,
             helpers: { ...helpers }
         });
 });


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/68](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/68)

To ensure user input cannot cause path traversal or reference files outside the intended template directory, the best fix is to validate or sanitize `req.params.file` before passing it to `resp.render()`. Since only template names within the "templates/server" folder should be renderable, we should restrict allowed filenames to a known safe pattern—e.g., alphanumeric strings (with optional underscore/hyphen), or use a whitelist.

A robust option is to only allow template names matching `/^[A-Za-z0-9_-]+$/`, so that requests with any suspicious characters (like slashes or dots) will be rejected or render a 404. Alternatively, installing and using the `sanitize-filename` module is possible but unnecessary if we only intend to allow simple, safe template names.

We only need to modify the handler at line 27-32 in Chapter 10/End of Chapter/part2app/src/server/server.ts, inserting input validation before rendering.

No external package is required for a simple regex-based validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
