### PR TITLE
Potential fix for code scanning alert no. 97: Uncontrolled data used in path expression

### DIFF
--- a/Chapter 10/End of Chapter/part2app/src/server/server.ts
+++ b/Chapter 10/End of Chapter/part2app/src/server/server.ts
@@ -6,6 +6,13 @@ import helmet from "helmet";
 //import { registerCustomTemplateEngine } from "./custom_engine";
 import { engine } from "express-handlebars";
 import * as helpers from "./template_helpers";
+import * as fs from "fs";
+import * as path from "path";
+
+const TEMPLATE_DIR = path.resolve(__dirname, "../../templates/server");
+const allowedTemplates = fs.readdirSync(TEMPLATE_DIR)
+    .filter(name => name.endsWith(".handlebars"))
+    .map(name => name.replace(/\.handlebars$/, ""));
 
 const port = 5000;
 
@@ -30,6 +37,10 @@ expressApp.get("/dynamic/:file", (req, resp) => {
     if (!/^[A-Za-z0-9_-]+$/.test(fileName)) {
         resp.status(400).send("Invalid template name");
         return;
+    if (!allowedTemplates.includes(fileName)) {
+        resp.status(404).send("Template not found");
+        return;
+    }
     }
     resp.render(`${fileName}.handlebars`,
         { message: "Hello template", req,


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/97](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/97)

The best way to fix this issue is to tightly control which templates are rendered in response to user requests. The current regex validation minimizes classic traversal attacks, but for defense-in-depth, you should use an explicit allow-list or validate that the resolved template path is within the allowed templates folder.

**Recommended fix:**  
1. Create an allow-list of permitted template names (if the set is fixed), or dynamically read the list of available templates from the `templates/server` folder.
2. In the route handler for `/dynamic/:file`, check that `fileName` is in the allow-list before rendering.
3. Optionally, perform additional normalization or sanity checks on the filename.
4. If the template is not allowed, return a `404 Not Found` or similar error.

Required changes:
- Add logic to enumerate the allowed templates (reading from disk or a hardcoded array).
- Change the route handler's validation: in addition to regex, check for membership in the allow-list before rendering.

Only changes within the shown code block in `server.ts` are permitted. We'll use Node's `fs` module (safe, standard).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
