### PR TITLE
Potential fix for code scanning alert no. 96: Missing rate limiting

### DIFF
--- a/Chapter 21/End of Chapter/sportsstore/src/routes/admin/index.ts
+++ b/Chapter 21/End of Chapter/sportsstore/src/routes/admin/index.ts
@@ -8,6 +8,12 @@ import { createDbManagementRoutes } from "./database_routes";
 
 const users: string[] = getConfig("admin:users", []);
 
+// Rate limiter for admin API endpoints
+const adminRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100 // limit each IP to 100 requests per windowMs
+});
+
 export const createAdminRoutes = (app: Express) => {
 
     app.use((req, resp, next) => {
@@ -44,10 +50,10 @@ export const createAdminRoutes = (app: Express) => {
     createAdminOrderRoutes(order_router);
     app.use("/api/orders", adminRateLimiter, apiAuth, order_router);
 
-    const adminRateLimiter = rateLimit({
-        windowMs: 15 * 60 * 1000, // 15 minutes
-        max: 100 // limit each IP to 100 requests per windowMs
-    });
+
+
+
+
 
     const db_router = Router();
     createDbManagementRoutes(db_router);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/96](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/96)

To fix the missing rate limiting, we should ensure the rate-limiting middleware (`adminRateLimiter`) is applied to the `/api/orders` endpoint. However, in the current code, `adminRateLimiter` is declared and defined _after_ its attempted use on line 45. This means that at the point of its usage, it is either `undefined` or throws a reference error, and thus does not actually rate-limit the route as intended.

**How to fix:**  
Move the definition of `adminRateLimiter` _before_ any of its usages, in particular before the line `app.use("/api/orders", adminRateLimiter, apiAuth, order_router);`.  
No further changes are needed, as `/api/database` is correctly rate-limited using the same middleware.

**Specifics:**  
- Move the block starting at `const adminRateLimiter = rateLimit({...})` (lines 47–50) up to immediately after the `const users` declaration and before any use in `app.use`.
- No new methods, imports, or definitions are needed, since `rateLimit` is already imported at the top.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
