### PR TITLE
Potential fix for code scanning alert no. 11: Missing CSRF middleware

### DIFF
--- a/Chapter 20/End of Chapter/sportsstore/package.json
+++ b/Chapter 20/End of Chapter/sportsstore/package.json
@@ -54,6 +54,7 @@
         "passport-google-oauth20": "^2.0.0",
         "sequelize": "^6.35.1",
         "sqlite3": "^5.1.6",
-        "validator": "^13.11.0"
+        "validator": "^13.11.0",
+        "csurf": "^1.11.0"
     }
 }

--- a/Chapter 20/End of Chapter/sportsstore/src/sessions.ts
+++ b/Chapter 20/End of Chapter/sportsstore/src/sessions.ts
@@ -3,6 +3,7 @@ import { Sequelize } from "sequelize";
 import { getConfig, getSecret } from "./config";
 import session from "express-session";
 import sessionStore from "connect-session-sequelize";
+import csurf from "csurf";
 
 const config = getConfig("sessions");
 
@@ -35,4 +36,7 @@ export const createSessions = (app: Express) => {
             maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
             sameSite: false, httpOnly: false, secure: false }
     }));    
+    
+    // Add CSRF protection middleware after session
+    app.use(csurf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/11](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/11)

To fix this problem, CSRF protection middleware must be added to the Express.js app, ideally right after session middleware and before any state-modifying route handlers. In the context of an Express TypeScript project, a well-supported option is the `csurf` middleware, which is actively maintained and easy to use. The fix requires importing and registering `csurf` as middleware after the session middleware (`app.use(session(...))`). This will ensure that all subsequent non-GET/HEAD/OPTIONS/TRACE requests require a valid CSRF token attached, which the attacker cannot forge without access to the session.

To implement this change in `Chapter 20/End of Chapter/sportsstore/src/sessions.ts`:
- Add an import for `csurf`.
- Immediately after `app.use(session(...))`, add `app.use(csurf())`.
- Optionally, ensure that errors from csurf (like missing tokens) are handled higher up, but that is not part of this code. 
- Note: The rest of the app (not in this snippet) will need to expose the CSRF token to forms/pages and validate it from clients on POST/PUT/DELETE/etc. requests.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
