### PR TITLE
Potential fix for code scanning alert no. 10: Missing CSRF middleware

### DIFF
--- a/Chapter 20/Beginning of Chapter/sportsstore/package.json
+++ b/Chapter 20/Beginning of Chapter/sportsstore/package.json
@@ -45,6 +45,7 @@
         "passport-google-oauth20": "^2.0.0",
         "sequelize": "^6.35.1",
         "sqlite3": "^5.1.6",
-        "validator": "^13.11.0"
+        "validator": "^13.11.0",
+        "lusca": "^1.7.0"
     }
 }

--- a/Chapter 20/Beginning of Chapter/sportsstore/src/sessions.ts
+++ b/Chapter 20/Beginning of Chapter/sportsstore/src/sessions.ts
@@ -3,6 +3,7 @@ import { Sequelize } from "sequelize";
 import { getConfig, getSecret } from "./config";
 import session from "express-session";
 import sessionStore from "connect-session-sequelize";
+import lusca from "lusca";
 
 const config = getConfig("sessions");
 
@@ -35,4 +36,5 @@ export const createSessions = (app: Express) => {
             maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
             sameSite: false, httpOnly: false, secure: false }
     }));    
+    app.use(lusca.csrf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/10](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/10)

To fix this problem, we should add a CSRF protection middleware after the session middleware is mounted in the `createSessions` function. The recommended approach is to use the widely adopted `lusca` package’s `csrf` middleware, which integrates easily with Express. This means adding a required import for `lusca`, and then calling `app.use(lusca.csrf())` after the session middleware setup. The changes should be applied only within the provided code in `Chapter 20/Beginning of Chapter/sportsstore/src/sessions.ts`. Specifically, you should:
- Import `lusca` at the top,
- Add `app.use(lusca.csrf())` as a line after the session middleware block (around line 38, before the closing brace). No other code changes should be made.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
