### PR TITLE
Potential fix for code scanning alert no. 12: Missing CSRF middleware

### DIFF
--- a/Chapter 21/Beginning of Chapter/sportsstore/package.json
+++ b/Chapter 21/Beginning of Chapter/sportsstore/package.json
@@ -54,6 +54,7 @@
         "passport-google-oauth20": "^2.0.0",
         "sequelize": "^6.35.1",
         "sqlite3": "^5.1.6",
-        "validator": "^13.11.0"
+        "validator": "^13.11.0",
+        "lusca": "^1.7.0"
     }
 }

--- a/Chapter 21/Beginning of Chapter/sportsstore/src/sessions.ts
+++ b/Chapter 21/Beginning of Chapter/sportsstore/src/sessions.ts
@@ -3,6 +3,7 @@ import { Sequelize } from "sequelize";
 import { getConfig, getSecret } from "./config";
 import session from "express-session";
 import sessionStore from "connect-session-sequelize";
+import lusca from "lusca";
 
 const config = getConfig("sessions");
 
@@ -35,4 +36,5 @@ export const createSessions = (app: Express) => {
             maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
             sameSite: false, httpOnly: false, secure: false }
     }));    
+    app.use(lusca.csrf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/12](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/12)

To ensure cookie-based session authentication is protected against CSRF, a CSRF middleware should be added directly after the session middleware initialization in this Express app. The industry-standard fix is to use a well-known Express-compatible CSRF middleware. The recommendation from CodeQL is to use `lusca.csrf`, which is a straightforward choice and well maintained. You will need to import `lusca`, and then add `app.use(lusca.csrf())` after `app.use(session(...))` inside the `createSessions` function.

Changes are needed in `Chapter 21/Beginning of Chapter/sportsstore/src/sessions.ts`:
- Add an import for `lusca`.
- After the session middleware (`app.use(session({ ... }))`), add the CSRF middleware: `app.use(lusca.csrf());`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
