### PR TITLE
Potential fix for code scanning alert no. 9: Missing CSRF middleware

### DIFF
--- a/Chapter 19/End of Chapter/sportsstore/package.json
+++ b/Chapter 19/End of Chapter/sportsstore/package.json
@@ -45,6 +45,7 @@
         "passport-google-oauth20": "^2.0.0",
         "sequelize": "^6.35.1",
         "sqlite3": "^5.1.6",
-        "validator": "^13.11.0"
+        "validator": "^13.11.0",
+        "lusca": "^1.7.0"
     }
 }

--- a/Chapter 19/End of Chapter/sportsstore/src/sessions.ts
+++ b/Chapter 19/End of Chapter/sportsstore/src/sessions.ts
@@ -3,6 +3,7 @@ import { Sequelize } from "sequelize";
 import { getConfig, getSecret } from "./config";
 import session from "express-session";
 import sessionStore from "connect-session-sequelize";
+import lusca from "lusca";
 
 const config = getConfig("sessions");
 
@@ -35,4 +36,5 @@ export const createSessions = (app: Express) => {
             maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
             sameSite: false, httpOnly: false, secure: false }
     }));    
+    app.use(lusca.csrf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/9](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/9)

To mitigate the CSRF vulnerability, CSRF middleware should be added to ensure that any state-changing requests are accompanied by a session-specific token. In the Node.js/Express ecosystem, this is commonly done using middleware such as `lusca` or `csurf`. Since the background recommends `lusca.csrf`, we will follow that guideline and add the relevant middleware after sessions are set up. 

**How and where to apply the fix:**
- Add an import for `lusca` in `sessions.ts`.
- After the `session` middleware is applied with `app.use(session({...}))`, add `app.use(lusca.csrf())` to ensure CSRF protection is enabled for subsequent requests.
- Only update the provided code, without affecting other parts of the codebase.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
