### PR TITLE
Potential fix for code scanning alert no. 8: Missing CSRF middleware

### DIFF
--- a/Chapter 19/Beginning of Chapter/sportsstore/package.json
+++ b/Chapter 19/Beginning of Chapter/sportsstore/package.json
@@ -41,6 +41,7 @@
         "helmet": "^7.1.0",
         "sequelize": "^6.35.1",
         "sqlite3": "^5.1.6",
-        "validator": "^13.11.0"
+        "validator": "^13.11.0",
+        "lusca": "^1.7.0"
     }
 }

--- a/Chapter 19/Beginning of Chapter/sportsstore/src/sessions.ts
+++ b/Chapter 19/Beginning of Chapter/sportsstore/src/sessions.ts
@@ -3,7 +3,7 @@ import { Sequelize } from "sequelize";
 import { getConfig, getSecret } from "./config";
 import session from "express-session";
 import sessionStore from "connect-session-sequelize";
-
+import lusca from "lusca";
 const config = getConfig("sessions");
 
 const secret = getSecret("COOKIE_SECRET");
@@ -34,4 +34,5 @@ export const createSessions = (app: Express) => {
         cookie: { maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
             sameSite: "strict" }
     }));
+    app.use(lusca.csrf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/8](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/8)

To fix this problem, you should add a CSRF-protection middleware to the Express app after setting up sessions. The recommended and well-known approach for Express apps using session-based auth is to use a middleware such as `lusca` or `csurf`. Since the CodeQL recommendation specifically suggests `lusca.csrf`, we will use that. Install the `lusca` package (if not already present), import it in this file, and add `app.use(lusca.csrf())` after the session middleware is set up (i.e., after line 36). You should also import `lusca` at the top of this file.

#### Changes needed in `Chapter 19/Beginning of Chapter/sportsstore/src/sessions.ts`:
- Add an import for `lusca`.
- Add the CSRF middleware right after the `session` middleware is initialized (after `app.use(session(...))`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
