### PR TITLE
Potential fix for code scanning alert no. 15: Exposure of private files

### DIFF
--- a/Chapter 18/Beginning of Chapter/sportsstore/src/server.ts
+++ b/Chapter 18/Beginning of Chapter/sportsstore/src/server.ts
@@ -16,7 +16,7 @@ expressApp.use(express.json());
 expressApp.use(express.urlencoded({extended: true}))
 
 expressApp.use(express.static("node_modules/bootstrap/dist"));
-expressApp.use(express.static("node_modules/bootstrap-icons"));
+expressApp.use('/bootstrap-icons', express.static("node_modules/bootstrap-icons/font"));
 
 createTemplates(expressApp);
 createSessions(expressApp);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/15](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/15)

To fix this vulnerability, restrict the exposed static assets to only those meant to be served, instead of the entire contents of `node_modules/bootstrap-icons`. You should specifically serve only the `font` or `icons` output directories, or serve only certain file extensions, depending on the package layout. For `bootstrap-icons`, public assets are typically distributed under a `font` or `icons` subdirectory. Change the server configuration to only expose that subdirectory, e.g., `node_modules/bootstrap-icons/font` or `node_modules/bootstrap-icons/icons`. Update line 19 to reflect this, and optionally add a route prefix such as `/bootstrap-icons`, so that the URL structure remains predictable and segregated.

No additional imports are needed for this change, and existing functionality (exposing the assets to the frontend) will be preserved.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
