### PR TITLE
Potential fix for code scanning alert no. 16: Exposure of private files

### DIFF
--- a/Chapter 18/End of Chapter/sportsstore/src/server.ts
+++ b/Chapter 18/End of Chapter/sportsstore/src/server.ts
@@ -16,7 +16,7 @@ expressApp.use(express.json());
 expressApp.use(express.urlencoded({extended: true}))
 
 expressApp.use(express.static("node_modules/bootstrap/dist"));
-expressApp.use(express.static("node_modules/bootstrap-icons"));
+expressApp.use(express.static("node_modules/bootstrap-icons/icons"));
 
 createTemplates(expressApp);
 createSessions(expressApp);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/16](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/16)

To fix the problem, restrict static file serving from `node_modules/bootstrap-icons` to only the subfolder containing the icon assets intended for client use (typically this will be the `icons` directory, e.g., `node_modules/bootstrap-icons/icons`). Adjust the `express.static` call to serve only that folder, thus minimizing the risk of exposing sensitive or private files. No additional methods or dependencies are required because we already use `express.static`. Only change line 19 in `src/server.ts` from serving the entire `bootstrap-icons` directory to serving its `icons` subfolder.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
