### PR TITLE
Potential fix for code scanning alert no. 62: Prototype-polluting function

### DIFF
--- a/Chapter 21/End of Chapter/sportsstore/src/config/merge.ts
+++ b/Chapter 21/End of Chapter/sportsstore/src/config/merge.ts
@@ -1,5 +1,9 @@
 export const merge = (target: any, source: any) : any => {
     Object.keys(source).forEach(key => {
+        // Prevent prototype pollution
+        if (key === "__proto__" || key === "constructor" || key === "prototype") {
+            return;
+        }
         if (typeof source[key] === "object" 
                 && !Array.isArray(source[key])) {
             if (Object.hasOwn(target, key)) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/62](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/62)

To fix the prototype pollution vulnerability, the best approach is to filter property names before performing assignment or recursion:

- **General fix approach:** Block keys that could access or pollute the prototype, namely `__proto__`, `constructor`, and possibly also `prototype`.
- **Detailed fix:** Before assigning `target[key] = ...` or `Object.assign(target, source[key])`, skip these assignments if `key` is one of the prohibited property names. This should be done at the start of every iteration in the `.forEach` loop in the `merge` function.
- **Region to change:** Insert an early-return (`continue`) if the key is `__proto__`, `constructor`, or `prototype` (since these can be used for prototype chain manipulation), on line 2-3 of `Chapter 21/End of Chapter/sportsstore/src/config/merge.ts`.
- **What is needed:** No new imports or functions are needed; this can be implemented inline using a simple key-name comparison.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
