### PR TITLE
Potential fix for code scanning alert no. 70: Uncontrolled data used in path expression

### DIFF
--- a/Chapter 11/End of Chapter/part2app/src/server/server.ts
+++ b/Chapter 11/End of Chapter/part2app/src/server/server.ts
@@ -27,7 +27,13 @@ registerFormMiddleware(expressApp);
 registerFormRoutes(expressApp);
 
 expressApp.get("/dynamic/:file", (req, resp) => {
-    resp.render(`${req.params.file}.handlebars`, 
+    const file = req.params.file;
+    // Only allow safe template names: letters, numbers, underscore, dash
+    if (!/^[a-zA-Z0-9_-]+$/.test(file)) {
+        resp.status(400).send("Invalid template name.");
+        return;
+    }
+    resp.render(`${file}.handlebars`, 
         { message: "Hello template", req, helpers: { ...helpers } });
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/70](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/70)

The best way to fix this issue is to validate the user-controlled file parameter before using it as a view name. Since templates should generally be known in advance (and not be arbitrary files), restrict `req.params.file` to allowed values using an allowlist, or, at a minimum, filter out any values containing path separators or other suspicious content (e.g., `..`, `/`, `\`).  

- **General approach:** Only permit template names that match a safe pattern: e.g., alphanumeric plus underscore/dash.  
- **Detailed approach:**  
  - In the `/dynamic/:file` route, check that the `file` parameter only contains safe characters (e.g., `/^[a-zA-Z0-9_-]+$/`).  
  - If invalid, respond with a 400 Bad Request; do not render a view.  
  - Only if valid, proceed to call `resp.render`.  
- Only lines inside the `/dynamic/:file` route handler (lines 29-32) need to be changed; no new external packages are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
