### PR TITLE
Potential fix for code scanning alert no. 31: Sensitive server cookie exposed to the client

### DIFF
--- a/Chapter 21/Beginning of Chapter/sportsstore/src/sessions.ts
+++ b/Chapter 21/Beginning of Chapter/sportsstore/src/sessions.ts
@@ -34,7 +34,7 @@ export const createSessions = (app: Express) => {
         resave: false, saveUninitialized: true,
         cookie: { 
             maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
-            sameSite: false, httpOnly: false, secure: false }
+            sameSite: false, httpOnly: true, secure: false }
     }));    
     app.use(lusca.csrf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/31](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/31)

To fix this issue, ensure the session cookie set by `express-session` has the `httpOnly` attribute enabled. This prevents client-side scripts from accessing the cookie data and mitigates risks from potential XSS attacks. In the code, this means changing the session middleware configuration in the `createSessions` function: in the `cookie` options passed to `session`, set `httpOnly: true` (either by removing the explicit `false` or by changing it), and ideally also consider setting `secure: true` if the application is served over HTTPS. However, since the CodeQL error is about `httpOnly`, only the `httpOnly` flag needs to be changed. The change is local to the session configuration block in `Chapter 21/Beginning of Chapter/sportsstore/src/sessions.ts`, lines 35-37.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
