### PR TITLE
Potential fix for code scanning alert no. 98: Uncontrolled data used in path expression

### DIFF
--- a/Chapter 11/End of Chapter/part2app/src/server/server.ts
+++ b/Chapter 11/End of Chapter/part2app/src/server/server.ts
@@ -11,6 +11,14 @@ const port = 5000;
 
 const expressApp: Express = express();
 
+// Define the explicit list of allowed template names (without .handlebars extension)
+const ALLOWED_TEMPLATES = [
+    "home",
+    "about",
+    "contact"
+    // Add more allowed template names as necessary
+];
+
 const proxy = httpProxy.createProxyServer({
     target: "http://localhost:5100", ws: true
 });
@@ -31,6 +39,11 @@ expressApp.get("/dynamic/:file", (req, resp) => {
     // Only allow safe template names: letters, numbers, underscore, dash
     if (!/^[a-zA-Z0-9_-]+$/.test(file)) {
         resp.status(400).send("Invalid template name.");
+        return;
+    }
+    // Further restrict to allowed template files
+    if (!ALLOWED_TEMPLATES.includes(file)) {
+        resp.status(404).send("Template not found.");
         return;
     }
     resp.render(`${file}.handlebars`, 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/98](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/98)

To fix the problem, we should avoid using user input directly to select templates, even after regex checks. Instead, define an explicit list of allowed template names. This list could be a simple array of acceptable strings. On each request, check if the user-provided `file` matches an entry in this allow-list. Only then should the template be rendered.

Specifically, in `Chapter 11/End of Chapter/part2app/src/server/server.ts`, define a constant (e.g., `ALLOWED_TEMPLATES`) with the allowed template base names, and in the route handler for `/dynamic/:file`, check if `file` is in `ALLOWED_TEMPLATES` before rendering. If not, return HTTP 404 or 400.

No new imports are required for this fix, just an additional list/lookup and a check.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
