### PR TITLE
Potential fix for code scanning alert no. 92: Missing rate limiting

### DIFF
--- a/Chapter 21/End of Chapter/sportsstore/src/routes/admin/index.ts
+++ b/Chapter 21/End of Chapter/sportsstore/src/routes/admin/index.ts
@@ -74,7 +74,7 @@ export const createAdminRoutes = (app: Express) => {
         resp.render("admin/admin_layout");
     })
 
-    app.get("/admin/products/edit/:id", userAuth, (req, resp) => {
+    app.get("/admin/products/edit/:id", adminRateLimiter, userAuth, (req, resp) => {
         resp.locals.content = `/api/products/edit/${req.params.id}`;
         resp.render("admin/admin_layout");
     })


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/92](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/92)

To fix the missing rate limiting, apply the `adminRateLimiter` middleware to the `/admin/products/edit/:id` route. This mirrors how rate limiting is applied to other admin dashboard endpoints, such as `/admin/orders` and `/admin/database`. To do this, update the route definition to include `adminRateLimiter` before `userAuth`. Only the route at line 77 (`app.get("/admin/products/edit/:id", userAuth, ...)`) in Chapter 21/End of Chapter/sportsstore/src/routes/admin/index.ts needs to be changed.

No new method definitions or imports are required, as `adminRateLimiter` is already defined and imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
