### PR TITLE
Potential fix for code scanning alert no. 85: Missing rate limiting

### DIFF
--- a/Chapter 21/Beginning of Chapter/sportsstore/package.json
+++ b/Chapter 21/Beginning of Chapter/sportsstore/package.json
@@ -55,6 +55,7 @@
         "sequelize": "^6.35.1",
         "sqlite3": "^5.1.6",
         "validator": "^13.11.0",
-        "lusca": "^1.7.0"
+        "lusca": "^1.7.0",
+        "express-rate-limit": "^8.1.0"
     }
 }

--- a/Chapter 21/Beginning of Chapter/sportsstore/src/routes/admin/index.ts
+++ b/Chapter 21/Beginning of Chapter/sportsstore/src/routes/admin/index.ts
@@ -1,4 +1,5 @@
 import { Express, NextFunction, Request, Response, Router } from "express";
+import rateLimit from "express-rate-limit";
 import { createAdminCatalogRoutes } from "./admin_catalog_routes";
 import { createAdminOrderRoutes } from "./admin_order_routes";
 import passport from "passport";
@@ -7,6 +8,14 @@ import { getConfig} from "../../config";
 const users: string[] = getConfig("admin:users", []);
 
 export const createAdminRoutes = (app: Express) => {
+
+    // Rate limiter: max 100 requests per 15 minutes per IP
+    const adminLimiter = rateLimit({
+        windowMs: 15 * 60 * 1000, // 15 minutes
+        max: 100, // limit each IP to 100 requests per windowMs
+        standardHeaders: true, // Return rate limit info in the RateLimit-* headers
+        legacyHeaders: false // Disable the X-RateLimit-* headers
+    });
 
     app.use((req, resp, next) => {
         resp.locals.layout = false;
@@ -49,20 +58,20 @@ export const createAdminRoutes = (app: Express) => {
         next();
     };
 
-    app.get("/admin", userAuth, (req, resp) => 
+    app.get("/admin", adminLimiter, userAuth, (req, resp) => 
         resp.redirect("/admin/products"));
 
-    app.get("/admin/products", userAuth, (req, resp) => {
+    app.get("/admin/products", adminLimiter, userAuth, (req, resp) => {
         resp.locals.content = "/api/products/table";
         resp.render("admin/admin_layout");
     })
 
-    app.get("/admin/products/edit/:id", userAuth, (req, resp) => {
+    app.get("/admin/products/edit/:id", adminLimiter, userAuth, (req, resp) => {
         resp.locals.content = `/api/products/edit/${req.params.id}`;
         resp.render("admin/admin_layout");
     })
 
-    app.get("/admin/orders", userAuth, (req, resp) => {
+    app.get("/admin/orders", adminLimiter, userAuth, (req, resp) => {
         resp.locals.content = "/api/orders/table";
         resp.render("admin/admin_layout");
     })


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/85](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/85)

To fix the problem, we should add a rate-limiting middleware to the admin routes, especially endpoints like `/admin/orders` and similar handlers that run expensive operations. The best way to do this is to use a widely-supported solution such as `express-rate-limit`. We'll install the `express-rate-limit` package, import it in this file, configure it (e.g., max 100 requests per 15 minutes), and apply the rate limiter to the relevant admin route(s) as middleware. In this file, insert the import for `express-rate-limit` at the top and instantiate the rate limiter before applying it to the `/admin/orders` and other sensitive admin routes (for consistency, we will also apply it to all `/admin/*` GET routes rather than just `/admin/orders`). This minimizes unexpected changes and maintains existing functionality while protecting admin endpoints from DoS attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
