### PR TITLE
Potential fix for code scanning alert no. 56: Prototype-polluting function

### DIFF
--- a/Chapter 18/End of Chapter/sportsstore/src/config/merge.ts
+++ b/Chapter 18/End of Chapter/sportsstore/src/config/merge.ts
@@ -1,5 +1,8 @@
 export const merge = (target: any, source: any) : any => {
     Object.keys(source).forEach(key => {
+        if (key === "__proto__" || key === "constructor") {
+            return;
+        }
         if (typeof source[key] === "object" 
                 && !Array.isArray(source[key])) {
             if (Object.hasOwn(target, key)) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/56](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/56)

To fix this prototype pollution vulnerability, we should prevent the merge function from copying or assigning risky property names, such as `__proto__` and `constructor`, from `source` to `target`. The best way is to add a conditional check at the start of each loop iteration that skips these keys entirely. Modify the function to check if `key` equals `"__proto__"` or `"constructor"`, and continue to the next iteration if so. Make this change in the `Chapter 18/End of Chapter/sportsstore/src/config/merge.ts` file within the merge function. No additional imports or helper methods are needed; simply conditionally skip dangerous property names before any merge/assignment operation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
