### PR TITLE
Potential fix for code scanning alert no. 28: Sensitive server cookie exposed to the client

### DIFF
--- a/Chapter 19/End of Chapter/sportsstore/src/sessions.ts
+++ b/Chapter 19/End of Chapter/sportsstore/src/sessions.ts
@@ -34,7 +34,7 @@ export const createSessions = (app: Express) => {
         resave: false, saveUninitialized: true,
         cookie: { 
             maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
-            sameSite: false, httpOnly: false, secure: false }
+            sameSite: false, httpOnly: true, secure: false }
     }));    
     app.use(lusca.csrf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/28](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/28)

To fix the problem, the session cookie should be configured so that the `httpOnly` attribute is set to `true`. This ensures that the sensitive session cookie is not accessible from client-side scripts, reducing the risk of compromise from XSS vulnerabilities. Specifically, edit the `cookie` property in the session middleware setup in file `Chapter 19/End of Chapter/sportsstore/src/sessions.ts`, changing `httpOnly: false` to `httpOnly: true`. This change is safe and maintains the intended session behavior, merely hardening the cookie settings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
