### PR TITLE
Potential fix for code scanning alert no. 59: Prototype-polluting function

### DIFF
--- a/Chapter 20/Beginning of Chapter/sportsstore/src/config/merge.ts
+++ b/Chapter 20/Beginning of Chapter/sportsstore/src/config/merge.ts
@@ -1,5 +1,8 @@
 export const merge = (target: any, source: any) : any => {
     Object.keys(source).forEach(key => {
+        if (key === "__proto__" || key === "constructor" || key === "prototype") {
+            return;
+        }
         if (typeof source[key] === "object" 
                 && !Array.isArray(source[key])) {
             if (Object.hasOwn(target, key)) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/59](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/59)

To fix prototype pollution in the `merge` function, we should block the dangerous key names (`__proto__`, `constructor`, and `prototype`) from being copied as properties. The best, least intrusive method is to add a guard at the start of the forEach loop that skips copying these special properties during the merge operation. This keeps all functionality intact except allowing assignment of these dangerous properties.

Specifically:
- In `Chapter 20/Beginning of Chapter/sportsstore/src/config/merge.ts`, modify the function so that keys equal to `"__proto__"`, `"constructor"`, or `"prototype"` are skipped/ignored during the recursive merge.

No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
