### PR TITLE
Potential fix for code scanning alert no. 111: Missing rate limiting

### DIFF
--- a/Chapter08/End_of_Chapter/webapp/package.json
+++ b/Chapter08/End_of_Chapter/webapp/package.json
@@ -29,6 +29,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "helmet": "^7.1.0",
-    "http-proxy": "^1.18.1"
+    "http-proxy": "^1.18.1",
+    "express-rate-limit": "^8.1.0"
   }
 }

--- a/Chapter08/End_of_Chapter/webapp/src/server.ts
+++ b/Chapter08/End_of_Chapter/webapp/src/server.ts
@@ -4,6 +4,7 @@ import { readHandler } from "./readHandler";
 import cors from "cors";
 import httpProxy from "http-proxy";
 import helmet from "helmet";
+import rateLimit from "express-rate-limit";
 
 const port = 5000;
 
@@ -35,7 +36,15 @@ expressApp.use(cors({
 }));
 expressApp.use(express.json());
 
-expressApp.post("/read", readHandler);
+
+const readLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
+
+expressApp.post("/read", readLimiter, readHandler);
 expressApp.use(express.static("static"));
 expressApp.use(express.static("node_modules/bootstrap/dist"));
 expressApp.use((req, resp) => proxy.web(req, resp));


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/111](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/111)

To fix this problem, we should introduce a rate-limiting middleware, such as `express-rate-limit`, to the `/read` route specifically (or to all routes, if broader protection is desired). The best, least disruptive fix is to:  
- Import the `express-rate-limit` package.
- Define a rate limiter (e.g., max 100 requests per 15 minutes).
- Apply this rate limiter as middleware only to the `/read` POST route in `server.ts`.

Only the `server.ts` file needs editing: add the import at the top, the limiter configuration near the route definitions, and apply the limiter to the `/read` route. No changes to the functionality of the handler or other routes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
