### PR TITLE
Potential fix for code scanning alert no. 110: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter08/End_of_Chapter/webapp/src/promises.ts
+++ b/Chapter08/End_of_Chapter/webapp/src/promises.ts
@@ -4,6 +4,6 @@ export const readHandler = (req: Request, resp: Response) => {
     // resp.json({
     //     message: "Hello, World"
     // });
-    resp.cookie("sessionID", "mysecretcode");
+    resp.cookie("sessionID", "mysecretcode", { secure: true, httpOnly: true });
     req.pipe(resp);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/110](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/110)

The best way to fix the issue is to set the `secure: true` flag in the `resp.cookie()` call, which ensures the browser will only send the cookie over HTTPS connections. For extra protection, you should also add the `httpOnly: true` flag, which prevents JavaScript access to the cookie in the browser, unless there’s a reason not to. To implement:
- Locate the line in Chapter08/End_of_Chapter/webapp/src/promises.ts where the cookie is set.
- Change the call to `resp.cookie("sessionID", "mysecretcode");` so it passes an object `{ secure: true, httpOnly: true }` as the third argument.
No additional methods or imports are needed as Express's response object supports these options directly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
