### PR TITLE
Potential fix for code scanning alert no. 100: Missing rate limiting

### DIFF
--- a/Chapter06/End_of_Chapter/webapp/src/server.ts
+++ b/Chapter06/End_of_Chapter/webapp/src/server.ts
@@ -21,7 +21,7 @@ expressApp.get("/sendcity", limiter, (req, resp) => {
     resp.sendFile("city.png", { root: "static"});
 });
 
-expressApp.get("/downloadcity", (req: Request, resp: Response) => {
+expressApp.get("/downloadcity", limiter, (req: Request, resp: Response) => {
     resp.download("static/city.png");
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/100](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/100)

To address the lack of rate limiting, the `/downloadcity` handler should be protected in the same way as `/sendcity`, by applying the existing `limiter` middleware to this route. This can be accomplished by adding the `limiter` middleware as a second argument to the `.get("/downloadcity", ...)` route, before the handler function itself. No additional definitions or imports are necessary as both `limiter` and its import are present in the existing code. Only a code edit to the relevant route declaration is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
