### PR TITLE
Potential fix for code scanning alert no. 76: Missing rate limiting

### DIFF
--- a/Chapter 20/End of Chapter/sportsstore/package.json
+++ b/Chapter 20/End of Chapter/sportsstore/package.json
@@ -55,6 +55,7 @@
         "sequelize": "^6.35.1",
         "sqlite3": "^5.1.6",
         "validator": "^13.11.0",
-        "csurf": "^1.11.0"
+        "csurf": "^1.11.0",
+        "express-rate-limit": "^8.1.0"
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/76](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/76)

To resolve the missing rate limiting, a rate-limiting middleware should be applied to the administrative endpoints protected by `userAuth`. The best way to do this is by using a well-known npm package, such as `express-rate-limit`, to create a limiter instance with reasonable defaults for admin operations (e.g., no more than 50 requests per 15 minutes per IP). The middleware should be inserted before the authentication check for these routes, so that abusive clients are rate-limited before any expensive authorization, rendering, or data access occurs. The specific edits are:  

- Import and configure `express-rate-limit`.
- Create a rate limiter instance in the module.
- Insert this limiter as middleware for the `/admin` routes (`/admin`, `/admin/products`, `/admin/products/edit/:id`, `/admin/orders`)—before `userAuth`.
- Add the needed import at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
