### PR TITLE
Potential fix for code scanning alert no. 74: Missing rate limiting

### DIFF
--- a/Chapter 20/End of Chapter/sportsstore/src/routes/admin/index.ts
+++ b/Chapter 20/End of Chapter/sportsstore/src/routes/admin/index.ts
@@ -15,6 +15,15 @@ export const createAdminRoutes = (app: Express) => {
         standardHeaders: true,
         legacyHeaders: false,
     });
+
+    // Set up rate limiter for admin API routes: max 50 requests per 15 minutes per IP
+    const apiLimiter = rateLimit({
+        windowMs: 15 * 60 * 1000, // 15 minutes
+        max: 50,
+        standardHeaders: true,
+        legacyHeaders: false,
+    });
+
     app.use((req, resp, next) => {
         resp.locals.layout = false;
         resp.locals.user = req.user;
@@ -43,11 +52,11 @@ export const createAdminRoutes = (app: Express) => {
 
     const cat_router = Router();
     createAdminCatalogRoutes(cat_router);
-    app.use("/api/products", apiAuth, cat_router);
+    app.use("/api/products", apiLimiter, apiAuth, cat_router);
 
     const order_router = Router();
     createAdminOrderRoutes(order_router);
-    app.use("/api/orders", apiAuth, order_router);
+    app.use("/api/orders", apiLimiter, apiAuth, order_router);
 
     const userAuth = (req: Request, resp: Response, next: NextFunction) => {
         if (!authCheck(req)) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/74](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/74)

To fix the missing rate limiting issue, we should add a rate limiting middleware to the `/api/products` and `/api/orders` route handlers, similar to how `adminLimiter` is applied to the `/admin` view routes.  
The best way—preserving existing functionality—is to define a dedicated rate limiter instance for API endpoints (e.g., `apiLimiter`). The API limiter can use similar configuration as `adminLimiter`, but may have a stricter, looser, or identical configuration depending on expected API load (in this solution, we will match the constraints for simplicity).

The following steps are needed:
- Create a new rate limiter instance (using `rateLimit` from `express-rate-limit`).
- Apply this middleware to the `/api/products` and `/api/orders` endpoints by adding it to their `app.use()` statements, i.e.:  
  `app.use("/api/products", apiLimiter, apiAuth, cat_router);`
- Ensure the limiter is constructed above these route definitions.
- All required code can be implemented in the shown file, using only existing imports.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
