### PR TITLE
Potential fix for code scanning alert no. 69: Uncontrolled data used in path expression

### DIFF
--- a/Chapter 11/Beginning of Chapter/part2app/src/server/server.ts
+++ b/Chapter 11/Beginning of Chapter/part2app/src/server/server.ts
@@ -26,8 +26,21 @@ expressApp.use(express.json());
 registerFormMiddleware(expressApp);
 registerFormRoutes(expressApp);
 
+// Allowlist of permitted template names (add to this list as needed)
+const allowedTemplates = [
+    "index",
+    "about",
+    "contact"
+];
+
 expressApp.get("/dynamic/:file", (req, resp) => {
-    resp.render(`${req.params.file}.handlebars`, 
+    const file = req.params.file;
+    // Only allow alphanumeric names, no slashes/dots
+    if (!/^[a-zA-Z0-9_-]+$/.test(file) || !allowedTemplates.includes(file)) {
+        resp.status(404).send("Not found");
+        return;
+    }
+    resp.render(`${file}.handlebars`, 
         { message: "Hello template", req, helpers: { ...helpers } });
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/69](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/69)

To address the possibility of uncontrolled user input in template file paths, we should ensure that only permitted template names are allowed to be rendered. The best practice here is to use an allowlist of safe file names (e.g., a list of template names that can be legitimately rendered by the application). The code should validate that `req.params.file` matches an entry in this allowlist before attempting to render the template; otherwise, it should respond with an error or a "not found" page.

To implement this:
- Define an array of permissible template names (without any path separators).
- Prior to rendering, check if `req.params.file` matches any name in the array.
- Only render the template if the input is allowed.
- Optionally, sanitize/validate the filename to ensure it is a simple alphanumeric string (e.g., using a regex).

All changes are confined to lines in `Chapter 11/Beginning of Chapter/part2app/src/server/server.ts`. We do not need to introduce any new imports since the required elements are either available in the standard library or already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
