### PR TITLE
Potential fix for code scanning alert no. 7: Missing CSRF middleware

### DIFF
--- a/Chapter 18/End of Chapter/sportsstore/package.json
+++ b/Chapter 18/End of Chapter/sportsstore/package.json
@@ -41,6 +41,7 @@
         "helmet": "^7.1.0",
         "sequelize": "^6.35.1",
         "sqlite3": "^5.1.6",
-        "validator": "^13.11.0"
+        "validator": "^13.11.0",
+        "lusca": "^1.7.0"
     }
 }

--- a/Chapter 18/End of Chapter/sportsstore/src/sessions.ts
+++ b/Chapter 18/End of Chapter/sportsstore/src/sessions.ts
@@ -3,7 +3,7 @@ import { Sequelize } from "sequelize";
 import { getConfig, getSecret } from "./config";
 import session from "express-session";
 import sessionStore from "connect-session-sequelize";
-
+import { csrf } from "lusca";
 const config = getConfig("sessions");
 
 const secret = getSecret("COOKIE_SECRET");
@@ -34,4 +34,6 @@ export const createSessions = (app: Express) => {
         cookie: { maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
             sameSite: "strict" }
     }));
+
+    app.use(csrf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/7](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/7)

**General fix:**  
To protect against CSRF attacks, a CSRF protection middleware must be enabled for the Express app, ideally after session middleware and before any route handlers. The widely used `lusca` library provides easy-to-use CSRF middleware for Express. It is best practice to import `csrf` from `lusca` (or use `csurf` as an alternative) and register it immediately after session setup using `app.use`.

**Specific fix:**  
- Import the `csrf` middleware from `lusca`.
- After installing the session middleware with `app.use(session(...))`, register the CSRF middleware with `app.use(csrf())`. This ensures CSRF tokens are checked for incoming requests and generated for views, matching the practice in the CodeQL-provided example.
- Only edit the given `sessions.ts` file, no changes or assumptions for the rest of the project.

**Required changes:**  
- Add import for `csrf` from `lusca`.
- Add the line `app.use(csrf());` immediately after session middleware setup (after line 36).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
