### PR TITLE
Potential fix for code scanning alert no. 6: Missing CSRF middleware

### DIFF
--- a/Chapter 18/Beginning of Chapter/sportsstore/package.json
+++ b/Chapter 18/Beginning of Chapter/sportsstore/package.json
@@ -39,6 +39,7 @@
         "handlebars": "^4.7.8",
         "helmet": "^7.1.0",
         "sequelize": "^6.35.1",
-        "sqlite3": "^5.1.6"
+        "sqlite3": "^5.1.6",
+        "lusca": "^1.7.0"
     }
 }

--- a/Chapter 18/Beginning of Chapter/sportsstore/src/sessions.ts
+++ b/Chapter 18/Beginning of Chapter/sportsstore/src/sessions.ts
@@ -3,7 +3,7 @@ import { Sequelize } from "sequelize";
 import { getConfig, getSecret } from "./config";
 import session from "express-session";
 import sessionStore from "connect-session-sequelize";
-
+import { csrf } from "lusca";
 const config = getConfig("sessions");
 
 const secret = getSecret("COOKIE_SECRET");
@@ -34,4 +34,5 @@ export const createSessions = (app: Express) => {
         cookie: { maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
             sameSite: "strict" }
     }));
+    app.use(csrf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/6](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/6)

The proper fix is to ensure CSRF protection middleware is installed and activated for all routes that rely on session/cookie authentication. The recommended approach is to use a well-known middleware, such as `lusca`'s `csrf` or `csurf`. Since the background suggests `lusca.csrf`, the best fix is to import and apply `lusca.csrf()` middleware immediately after sessions are configured, ensuring all subsequent routes and handlers benefit from the protection. 

**Concrete steps:**
- Import `csrf` from the `lusca` package at the top of the file.
- After the `app.use(session(...))` call inside `createSessions`, call `app.use(csrf())`.
- Ensure no unnecessary changes are made outside this region.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
