### PR TITLE
Potential fix for code scanning alert no. 5: Missing CSRF middleware

### DIFF
--- a/Chapter 17/End of Chapter/sportsstore/package.json
+++ b/Chapter 17/End of Chapter/sportsstore/package.json
@@ -39,6 +39,7 @@
         "handlebars": "^4.7.8",
         "helmet": "^7.1.0",
         "sequelize": "^6.35.1",
-        "sqlite3": "^5.1.6"
+        "sqlite3": "^5.1.6",
+        "lusca": "^1.7.0"
     }
 }

--- a/Chapter 17/End of Chapter/sportsstore/src/sessions.ts
+++ b/Chapter 17/End of Chapter/sportsstore/src/sessions.ts
@@ -3,6 +3,7 @@ import { Sequelize } from "sequelize";
 import { getConfig, getSecret } from "./config";
 import session from "express-session";
 import sessionStore from "connect-session-sequelize";
+import lusca from "lusca";
 
 const config = getConfig("sessions");
 
@@ -34,4 +35,7 @@ export const createSessions = (app: Express) => {
         cookie: { maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
             sameSite: "strict" }
     }));
+
+    // Add CSRF protection middleware
+    app.use(lusca.csrf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/5](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/5)

To fix the missing CSRF middleware, the best approach is to add a well-established CSRF protection middleware directly after the session middleware in the `createSessions` function within `sessions.ts`. `lusca` or `csurf` are popular packages widely used for this purpose. We will use `lusca` as recommended by the CodeQL guidance.

**Steps:**
- Import the `lusca` package and specifically use its `csrf` middleware.
- After setting up the session middleware with `app.use(session(...))`, add `app.use(lusca.csrf())`.
- If needed, expose the CSRF token to rendered views/forms (not shown here, but should be considered when modifying templates/frontend).
- Make sure to add an import statement for `lusca`.

No change to existing session or database functionality is needed; just the middleware addition and necessary import.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
