### PR TITLE
Potential fix for code scanning alert no. 4: Missing CSRF middleware

### DIFF
--- a/Chapter 15/End of Chapter/part2app/package.json
+++ b/Chapter 15/End of Chapter/part2app/package.json
@@ -33,7 +33,8 @@
     "passport-local": "^1.0.0",
     "sequelize": "^6.35.1",
     "sqlite3": "^5.1.6",
-    "validator": "^13.11.0"
+    "validator": "^13.11.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.2",

--- a/Chapter 15/End of Chapter/part2app/src/server/forms.ts
+++ b/Chapter 15/End of Chapter/part2app/src/server/forms.ts
@@ -3,6 +3,7 @@ import repository  from "./data";
 import cookieMiddleware from "cookie-parser";
 import { sessionMiddleware } from "./sessions/session_helpers";
 import { roleGuard } from "./auth";
+import lusca from "lusca";
 import { Result } from "./data/repository";
 
 const rowLimit = 10;
@@ -11,6 +12,7 @@ export const registerFormMiddleware = (app: Express) => {
     app.use(express.urlencoded({extended: true}))
     app.use(cookieMiddleware("mysecret"));
     app.use(sessionMiddleware());
+    app.use(lusca.csrf());
 }
 
 export const registerFormRoutes = (app: Express) => {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/4](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/4)

To fix the CSRF vulnerability, you should add CSRF protection middleware right after setting up parsers and session middleware, before any request handlers that process sensitive data. `lusca` is a common middleware to achieve this. The appropriate fix involves:

- Importing the `lusca` package and applying its `csrf()` middleware after parsing cookies and registering sessions, inside the `registerFormMiddleware` function in `forms.ts`.
- The CSRF middleware must be applied before any route that handles data mutations.
- No changes to the structure of requests or forms are needed unless you wish to expose CSRF tokens in rendered forms, but this can be handled later.

Changes:
- Add `import lusca from "lusca";` to the imports.
- Add `app.use(lusca.csrf());` after sessionMiddleware registration.
- No other additions or modifications are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
