### PR TITLE
Potential fix for code scanning alert no. 3: Missing CSRF middleware

### DIFF
--- a/Chapter 14/End of Chapter/part2app/package.json
+++ b/Chapter 14/End of Chapter/part2app/package.json
@@ -29,7 +29,8 @@
     "multer": "^1.4.5-lts.1",
     "sequelize": "^6.35.1",
     "sqlite3": "^5.1.6",
-    "validator": "^13.11.0"
+    "validator": "^13.11.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.2",

--- a/Chapter 14/End of Chapter/part2app/src/server/forms.ts
+++ b/Chapter 14/End of Chapter/part2app/src/server/forms.ts
@@ -1,4 +1,5 @@
 import express, { Express } from "express";
+import csrf from "lusca";
 import repository  from "./data";
 import { getJsonCookie, setJsonCookie } from "./cookies";
 import cookieMiddleware from "cookie-parser";
@@ -12,6 +13,7 @@ export const registerFormMiddleware = (app: Express) => {
     app.use(cookieMiddleware("mysecret"));
     //app.use(customSessionMiddleware());
     app.use(sessionMiddleware());
+    app.use(csrf());
 }
 
 export const registerFormRoutes = (app: Express) => {
@@ -19,7 +21,8 @@ export const registerFormRoutes = (app: Express) => {
     app.get("/form", async (req, resp) => {
         resp.render("age", {
             history: await repository.getAllResults(rowLimit),
-            personalHistory: getSession(req).personalHistory
+            personalHistory: getSession(req).personalHistory,
+            csrfToken: req.csrfToken && req.csrfToken()
         });
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/3](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/3)

To mitigate CSRF attacks, the best fix is to add a CSRF middleware such as [`lusca.csrf`](https://github.com/krakenjs/lusca) to all routes that serve authenticated, state-changing requests. In this file, you should:

- Import the CSRF middleware from `lusca`.
- Add `app.use(csrf())` in your `registerFormMiddleware`, after cookie and session middleware. (Order is important: cookie/session come first, then CSRF.)
- For GET requests, embed the CSRF token in forms so that POST requests include it.  
- For POST requests, the CSRF middleware will automatically validate token presence in the request.

Since you only have access to this file, update `registerFormMiddleware` to add the middleware, and ensure the GET route renders or exposes the token for use in forms. You can provide the token to the view by adding `req.csrfToken()` to the context of `resp.render` in the GET `/form` handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
