### PR TITLE
Potential fix for code scanning alert no. 2: Missing CSRF middleware

### DIFF
--- a/Chapter 14/Beginning of Chapter/part2app/package.json
+++ b/Chapter 14/Beginning of Chapter/part2app/package.json
@@ -26,7 +26,8 @@
     "multer": "^1.4.5-lts.1",
     "sequelize": "^6.35.1",
     "sqlite3": "^5.1.6",
-    "validator": "^13.11.0"
+    "validator": "^13.11.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.2",

--- a/Chapter 14/Beginning of Chapter/part2app/src/server/forms.ts
+++ b/Chapter 14/Beginning of Chapter/part2app/src/server/forms.ts
@@ -4,6 +4,7 @@ import { getJsonCookie, setJsonCookie } from "./cookies";
 import cookieMiddleware from "cookie-parser";
 import { customSessionMiddleware } from "./sessions/middleware";
 import { getSession, sessionMiddleware } from "./sessions/session_helpers";
+import lusca from "lusca";
 
 const rowLimit = 10;
 
@@ -12,6 +13,7 @@ export const registerFormMiddleware = (app: Express) => {
     app.use(cookieMiddleware("mysecret"));
     //app.use(customSessionMiddleware());
     app.use(sessionMiddleware());
+    app.use(lusca.csrf());
 }
 
 export const registerFormRoutes = (app: Express) => {
@@ -19,7 +21,8 @@ export const registerFormRoutes = (app: Express) => {
     app.get("/form", async (req, resp) => {
         resp.render("age", {
             history: await repository.getAllResults(rowLimit),
-            personalHistory: getSession(req).personalHistory
+            personalHistory: getSession(req).personalHistory,
+            csrfToken: req.csrfToken()
         });
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/2](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/2)

To fix the missing CSRF middleware issue, we should add a well-known CSRF protection library to the middleware stack for all state-changing routes. The recommended solution is to use Lusca's CSRF protection middleware, which can easily be integrated. This requires:
- Importing Lusca (specifically, its `csrf` middleware).
- Applying `lusca.csrf()` as a middleware in the `registerFormMiddleware` function after cookie and session middleware so that CSRF tokens are generated and validated for relevant requests.
- Ensuring generated CSRF tokens are included in forms rendered by server-side templates. This requires exposing the CSRF token (from `req.csrfToken()`) to the template context in the `/form` GET route.
- Updating the form template (not shown here) to include a hidden field for the CSRF token (as `<input type="hidden" name="_csrf" value="{{csrfToken}}"/>`).

All changes should be limited to the shown code in Chapter 14/Beginning of Chapter/part2app/src/server/forms.ts. We will:
1. Add an import for Lusca.
2. Add Lusca CSRF middleware in `registerFormMiddleware`.
3. Update the `/form` GET route to expose the CSRF token to the template context.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
