### PR TITLE
Potential fix for code scanning alert no. 3: Missing CSRF middleware

### DIFF
--- a/Chapter 14/End of Chapter/part2app/src/server/forms.ts
+++ b/Chapter 14/End of Chapter/part2app/src/server/forms.ts
@@ -9,11 +9,11 @@ import { getSession, sessionMiddleware } from "./sessions/session_helpers";
 const rowLimit = 10;
 
 export const registerFormMiddleware = (app: Express) => {
-    app.use(express.urlencoded({extended: true}))
+    app.use(express.urlencoded({extended: true}));
     app.use(cookieMiddleware("mysecret"));
-    //app.use(customSessionMiddleware());
     app.use(sessionMiddleware());
-    app.use(csrf());
+    // If you use a custom session middleware, place here
+    app.use(csrf()); // Register CSRF *after* session and cookie, and *before* routes
 }
 
 export const registerFormRoutes = (app: Express) => {
@@ -22,7 +22,7 @@ export const registerFormRoutes = (app: Express) => {
         resp.render("age", {
             history: await repository.getAllResults(rowLimit),
             personalHistory: getSession(req).personalHistory,
-            csrfToken: req.csrfToken && req.csrfToken()
+            csrfToken: req.csrfToken ? req.csrfToken() : ""
         });
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/3](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/3)

To properly fix this problem, we must ensure that CSRF protection middleware is active and enforced on all state-changing routes (especially POST `/form`). The best way is to make sure that `app.use(csrf())` is registered sufficiently early, i.e., before any handlers dealing with cookies or sessions and before any route handlers. The correct registration order for middleware is: cookie parser, session (if needed), then CSRF, then routes. Additionally, when rendering forms, the CSRF token must be added to the template context so that it is embedded in the HTML and sent with POST requests, typically using a hidden field.

Thus, in `registerFormMiddleware`,:
- Ensure the order is: cookieParser → sessionMiddleware → csrf → routes.
In `registerFormRoutes`:
- On the GET `/form`, generate and render the CSRF token for the form.
- On the POST `/form`, check that the CSRF token is submitted and validated (lusca validates automatically if the token is submitted in the request body/header).
- Add a hidden input `<input type="hidden" name="_csrf" value="{{csrfToken}}">` to your `age` template if not already present (template edit is out of scope unless shown).

If the code calls a custom session middleware, ensure that the CSRF middleware runs after session is initialized—CSRF tokens are stored in sessions.

**Changes to make:**
- Confirm and fix the order in `registerFormMiddleware` so CSRF middleware is registered at the correct place.
- Ensure the CSRF token is included in the context during form rendering, and that it is checked for POST requests by lusca automatically.
- No need for further code in the POST handler: lusca will reject requests with invalid/missing CSRF tokens before reaching the handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
