### PR TITLE
Potential fix for code scanning alert no. 1: Missing CSRF middleware

### DIFF
--- a/Chapter 13/End of Chapter/part2app/package.json
+++ b/Chapter 13/End of Chapter/part2app/package.json
@@ -24,7 +24,8 @@
     "multer": "^1.4.5-lts.1",
     "sequelize": "^6.35.1",
     "sqlite3": "^5.1.6",
-    "validator": "^13.11.0"
+    "validator": "^13.11.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.2",

--- a/Chapter 13/End of Chapter/part2app/src/server/forms.ts
+++ b/Chapter 13/End of Chapter/part2app/src/server/forms.ts
@@ -4,7 +4,7 @@ import { getJsonCookie, setJsonCookie } from "./cookies";
 import cookieMiddleware from "cookie-parser";
 import { customSessionMiddleware } from "./sessions/middleware";
 import { getSession, sessionMiddleware } from "./sessions/session_helpers";
-
+import lusca from "lusca";
 const rowLimit = 10;
 
 export const registerFormMiddleware = (app: Express) => {
@@ -12,6 +12,7 @@ export const registerFormMiddleware = (app: Express) => {
     app.use(cookieMiddleware("mysecret"));
     //app.use(customSessionMiddleware());
     app.use(sessionMiddleware());
+    app.use(lusca.csrf());
 }
 
 export const registerFormRoutes = (app: Express) => {
@@ -19,7 +20,8 @@ export const registerFormRoutes = (app: Express) => {
     app.get("/form", async (req, resp) => {
         resp.render("age", {
             history: await repository.getAllResults(rowLimit),
-            personalHistory: getSession(req).personalHistory
+            personalHistory: getSession(req).personalHistory,
+            csrfToken: req.csrfToken()
         });
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/1](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/1)

To best address this vulnerability, we should add CSRF protection middleware to the request flow before serving user-controlled POST routes. A well-known, simple solution is to use `lusca.csrf` middleware. The best way is to:

- Import `lusca`, and set up its CSRF middleware within the `registerFormMiddleware` function, immediately after existing session and cookie middleware.
- When using CSRF tokens, make sure to provide a token to the rendered forms on GET requests, so that forms can include these tokens in POST submissions. In Express and most templating engines, this is handled by setting a CSRF token value from `req.csrfToken()` as a variable in the context for the form rendering.

**Specific changes:**
- Add `lusca` import at the top.
- Add `app.use(lusca.csrf())` after session (on line 15).
- In the GET route for `/form`, include a CSRF token in the context rendered, e.g. `csrfToken: req.csrfToken()`.
- This allows the form template to insert `<input type="hidden" name="_csrf" value="{{csrfToken}}">` or similar.
- There is no need to manually check for the token in the handler: the middleware will throw 403 if missing/incorrect.
- No need to modify how session data is handled otherwise.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
