### PR TITLE
Potential fix for code scanning alert no. 108: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter08/Beginning_of_Chapter/webapp/src/promises.ts
+++ b/Chapter08/Beginning_of_Chapter/webapp/src/promises.ts
@@ -4,6 +4,6 @@ export const readHandler = (req: Request, resp: Response) => {
     // resp.json({
     //     message: "Hello, World"
     // });
-    resp.cookie("sessionID", "mysecretcode");
+    resp.cookie("sessionID", "mysecretcode", { secure: true, httpOnly: true });
     req.pipe(resp);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/108](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/108)

To fix this issue, ensure that the `sessionID` cookie is only transmitted over secure HTTPS connections by setting the `secure` attribute. Additionally, it is best practice to set the `httpOnly` attribute to prevent client-side JavaScript from accessing the cookie. The necessary change is to update the call to `resp.cookie` on line 7 to include an options object with `secure: true` and preferably `httpOnly: true`. This requires no new imports, as Express's `Response.cookie` method supports these options. Only line 7 of Chapter08/Beginning_of_Chapter/webapp/src/promises.ts needs to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
