### PR TITLE
Potential fix for code scanning alert no. 104: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter07/End_of_Chapter/webapp/src/readHandler.ts
+++ b/Chapter07/End_of_Chapter/webapp/src/readHandler.ts
@@ -4,6 +4,6 @@ export const readHandler = (req: Request, resp: Response) => {
     // resp.json({
     //     message: "Hello, World"
     // });
-    resp.cookie("sessionID", "mysecretcode");
+    resp.cookie("sessionID", "mysecretcode", { secure: true, httpOnly: true });
     req.pipe(resp);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/104](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/104)

To fix the problem, the `resp.cookie()` method should be used with the proper cookie configuration options to mark the cookie as `secure` (only sent over HTTPS) and `httpOnly` (not accessible via JavaScript), which are best practices for sensitive cookies. Only the given region (line 7 of `readHandler.ts`) needs to be updated. This requires passing a third options object to `resp.cookie()`. No new methods or library imports are needed, as `express` supports these options natively.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
