### PR TITLE
Potential fix for code scanning alert no. 61: Prototype-polluting function

### DIFF
--- a/Chapter 21/Beginning of Chapter/sportsstore/src/config/merge.ts
+++ b/Chapter 21/Beginning of Chapter/sportsstore/src/config/merge.ts
@@ -1,5 +1,9 @@
 export const merge = (target: any, source: any) : any => {
     Object.keys(source).forEach(key => {
+        // Prevent prototype pollution
+        if (key === "__proto__" || key === "constructor" || key === "prototype") {
+            return;
+        }
         if (typeof source[key] === "object" 
                 && !Array.isArray(source[key])) {
             if (Object.hasOwn(target, key)) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/61](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/61)

To fix this prototype pollution vulnerability:
- The function must *block* or *skip* dangerous property keys during merging and assignment—specifically, keys `"__proto__"`, `"constructor"`, and optionally `"prototype"`.
- Update both merge/recursion path (line 6) and assignment paths (lines 8 and 11) to skip these keys.
- The best way is to insert a check at the start of the `forEach` callback that skips such keys.

Changes are limited to the `Chapter 21/Beginning of Chapter/sportsstore/src/config/merge.ts` file, within the `merge` function.  
No new external dependencies are needed: code can be implemented simply with an `if` check.  
No need for new method definitions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
