### PR TITLE
Potential fix for code scanning alert no. 60: Prototype-polluting function

### DIFF
--- a/Chapter 20/End of Chapter/sportsstore/src/config/merge.ts
+++ b/Chapter 20/End of Chapter/sportsstore/src/config/merge.ts
@@ -1,5 +1,6 @@
 export const merge = (target: any, source: any) : any => {
     Object.keys(source).forEach(key => {
+        if (key === "__proto__" || key === "constructor" || key === "prototype") return;
         if (typeof source[key] === "object" 
                 && !Array.isArray(source[key])) {
             if (Object.hasOwn(target, key)) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/60](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/60)

To fix the problem, we must prevent the merge function from copying or assigning dangerous property names (`__proto__`, `constructor`, or `prototype`) from the source object to the target object. This can be done by adding a check inside the iteration to skip such keys. The best approach here is to filter these property names at the top of the forEach loop so that neither direct assignment nor recursion will process these keys. This change should occur inside `Chapter 20/End of Chapter/sportsstore/src/config/merge.ts`, inside the merge function, specifically in its iteration over `Object.keys(source)`. No additional imports or methods are needed, just a conditional check.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
