### PR TITLE
Potential fix for code scanning alert no. 170: Prototype-polluting function

### DIFF
--- a/Chapter19/End_of_Chapter/sportsstore/src/config/merge.ts
+++ b/Chapter19/End_of_Chapter/sportsstore/src/config/merge.ts
@@ -1,5 +1,6 @@
 export const merge = (target: any, source: any) : any => {
     Object.keys(source).forEach(key => {
+        if (key === "__proto__" || key === "constructor" || key === "prototype") return;
         if (typeof source[key] === "object" 
                 && !Array.isArray(source[key])) {
             if (Object.hasOwn(target, key)) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/170](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/170)

To correctly fix the issue in `Chapter19/End_of_Chapter/sportsstore/src/config/merge.ts`, you should block potentially dangerous property names (`__proto__`, `constructor`, and optionally `prototype`) from being copied from `source` to `target`. This applies to both direct assignment (`target[key] = source[key]`) and usage of `Object.assign(target, source[key])`. Implement this by inserting a guard clause immediately in the loop: `if (key === '__proto__' || key === 'constructor' || key === 'prototype') return;`. 

In more detail:
- Modify the forEach loop to skip keys with those dangerous names before any assignment or recursion.
- This prevents prototype pollution by ensuring the `merge` function cannot assign to or recurse into those special object properties.
- No imports or external dependencies are required.
- All code changes are localized to the single provided function in the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
