### PR TITLE
Potential fix for code scanning alert no. 169: Prototype-polluting function

### DIFF
--- a/Chapter19/Beginning_of_Chapter/sportsstore/src/config/merge.ts
+++ b/Chapter19/Beginning_of_Chapter/sportsstore/src/config/merge.ts
@@ -1,5 +1,12 @@
 export const merge = (target: any, source: any) : any => {
     Object.keys(source).forEach(key => {
+        if (
+            key === "__proto__" ||
+            key === "constructor" ||
+            key === "prototype"
+        ) {
+            return; // Skip dangerous keys to prevent prototype pollution
+        }
         if (typeof source[key] === "object" 
                 && !Array.isArray(source[key])) {
             if (Object.hasOwn(target, key)) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/169](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/169)

To fix the vulnerability, the merge function should block unsafe property names that can result in prototype pollution. Specifically, property names such as `"__proto__"`, `"constructor"`, and `"prototype"` must not be copied from the source object into the target. We should add a check in the `forEach` loop to skip any keys with these values. This should be done before any assignment or recursion. No external dependencies are required; native JavaScript checks suffice.

Edit the file `Chapter19/Beginning_of_Chapter/sportsstore/src/config/merge.ts`:
- Add a condition inside the `forEach` loop to skip keys named `"__proto__"`, `"constructor"`, or `"prototype"`.
- Do not alter the existing logic for other keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
