### PR TITLE
Potential fix for code scanning alert no. 168: Prototype-polluting function

### DIFF
--- a/Chapter18/Beginning_of_Chapter/sportsstore/src/config/merge.ts
+++ b/Chapter18/Beginning_of_Chapter/sportsstore/src/config/merge.ts
@@ -1,5 +1,8 @@
 export const merge = (target: any, source: any) : any => {
     Object.keys(source).forEach(key => {
+        if (key === "__proto__" || key === "constructor" || key === "prototype") {
+            return;
+        }
         if (typeof source[key] === "object" 
                 && !Array.isArray(source[key])) {
             if (Object.hasOwn(target, key)) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/168](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/168)

To fix the problem, we should block unsafe property names, such as `__proto__`, `constructor`, and (possibly) `prototype`, from being copied or merged into the `target`. This can be done by checking each `key` before performing any assignment, recursion, or call to `Object.assign`. A simple way to do this is to skip any key that matches these dangerous property names. This change can be implemented within the function `merge` in `Chapter18/Beginning_of_Chapter/sportsstore/src/config/merge.ts`, affecting the main forEach block. No new methods or imports are needed; just logic to skip keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
