### PR TITLE
Potential fix for code scanning alert no. 166: Prototype-polluting function

### DIFF
--- a/Chapter17/Beginning_of_Chapter/sportsstore/src/config/merge.ts
+++ b/Chapter17/Beginning_of_Chapter/sportsstore/src/config/merge.ts
@@ -1,5 +1,8 @@
 export const merge = (target: any, source: any) : any => {
     Object.keys(source).forEach(key => {
+        if (key === "__proto__" || key === "constructor" || key === "prototype") {
+            return;
+        }
         if (typeof source[key] === "object" 
                 && !Array.isArray(source[key])) {
             if (Object.hasOwn(target, key)) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/166](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/166)

Prototype pollution can be prevented by blocking assignments to dangerous property names such as `__proto__` and `constructor` (and sometimes `prototype`). The fix is to add a check in the `merge` function that skips these property names whenever iterating the `source` properties. This check should be applied wherever properties are assigned or where the recursion occurs (lines 6, 8, and 11). The best place is the beginning of the property iteration, short-circuiting before any merge or assignment is performed.

Update the loop at line 2 to skip any properties where `key` is `__proto__`, `constructor`, or optionally `prototype` before calling `merge`, `Object.assign`, or assigning to `target[key]`. This ensures that potentially polluting assignments are never attempted.

Only the file `Chapter17/Beginning_of_Chapter/sportsstore/src/config/merge.ts` needs updating, by editing inside the property iteration at line 2, and inserting the necessary guards.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
