### PR TITLE
Potential fix for code scanning alert no. 165: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter21/End_of_Chapter/sportsstore/src/sessions.ts
+++ b/Chapter21/End_of_Chapter/sportsstore/src/sessions.ts
@@ -34,7 +34,7 @@ export const createSessions = (app: Express) => {
         resave: false, saveUninitialized: true,
         cookie: { 
             maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
-            sameSite: false, httpOnly: false, secure: false }
+            sameSite: false, httpOnly: false, secure: (process.env.NODE_ENV === 'production') }
     }));
 
     app.use(csrf());


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/165](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/165)

To fix this problem, ensure that the session cookie is only transmitted over encrypted connections by enabling the `secure` flag in the cookie options, as recommended for authentication/session cookies. This should be set by default, but you may want to conditionally set it based on whether the app is running in production and whether HTTPS is used (to avoid breaking local development).

The code to fix: In the session middleware setup (lines 32–38), update the `secure` option inside the `cookie` settings. Preferably, use an environment variable or configuration property to determine if the flag should be set to `true`. Express conventionally uses `process.env.NODE_ENV === 'production'` to determine production mode. Therefore:

- Set `secure: process.env.NODE_ENV === 'production'`
- Optionally, also set `sameSite: 'strict'` and `httpOnly: true` for additional protection, but only change those if appropriate for the app's functional requirements.

Changes:
- In Chapter21/End_of_Chapter/sportsstore/src/sessions.ts, update the cookie options in the `session()` middleware setup to set `secure` to `true` when in production.

Dependencies:
- No new dependencies required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
