### PR TITLE
Potential fix for code scanning alert no. 164: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter21/Beginning_of_Chapter/sportsstore/src/sessions.ts
+++ b/Chapter21/Beginning_of_Chapter/sportsstore/src/sessions.ts
@@ -34,7 +34,7 @@ export const createSessions = (app: Express) => {
         resave: false, saveUninitialized: true,
         cookie: { 
             maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
-            sameSite: false, httpOnly: true, secure: false }
+            sameSite: false, httpOnly: true, secure: process.env.NODE_ENV === "production" }
     }));    
     app.use(lusca.csrf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/164](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/164)

To fix this issue, the session cookie configuration should be updated so that the `secure` attribute is set to `true`, which ensures the browser only transmits the cookie over HTTPS connections. If users are connecting via HTTP during development, you can add logic to set `secure: true` when the application is running in production (i.e., when a `NODE_ENV` environment variable is set to `"production"`), and `false` otherwise. This maintains dev workflow while enforcing best practices in production. 

This change should be made in the cookie options within the `app.use(session(...))` middleware setup, specifically at line 37. No new imports are needed. The attribute should be set conditionally based on environment variables, but unconditionally setting to `true` is the most secure option.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
