### PR TITLE
Potential fix for code scanning alert no. 163: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter20/End_of_Chapter/sportsstore/src/sessions.ts
+++ b/Chapter20/End_of_Chapter/sportsstore/src/sessions.ts
@@ -34,7 +34,7 @@ export const createSessions = (app: Express) => {
         resave: false, saveUninitialized: true,
         cookie: { 
             maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
-            sameSite: false, httpOnly: false, secure: false }
+            sameSite: false, httpOnly: true, secure: process.env.NODE_ENV === 'production' }
     }));    
     
     // Add CSRF protection middleware after session


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/163](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/163)

To fix the problem, we should ensure that the session cookie is only sent over secure connections by setting `secure: true` in cookie options, except (optionally) in explicit non-production/development environments.  
The single best fix is to make the value of `secure` conditional, either via a config variable, environment variable, or by checking for `NODE_ENV !== "production"`.  
In practice, this involves modifying the cookie properties in the configuration for `express-session` within the `createSessions` function, on lines 35–37 of `Chapter20/End_of_Chapter/sportsstore/src/sessions.ts`.

If the deployment supports HTTPS, set `secure: true`, and if local development (where HTTPS may not be supported), set `secure: false` *only with clear intent* and possibly a warning.  
We should also set `httpOnly: true` to ensure the cookie is not accessible via JavaScript (unless there is an explicit reason otherwise).  
Existing imports suffice, as no external modules are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
