### PR TITLE
Potential fix for code scanning alert no. 161: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter19/End_of_Chapter/sportsstore/src/sessions.ts
+++ b/Chapter19/End_of_Chapter/sportsstore/src/sessions.ts
@@ -34,7 +34,7 @@ export const createSessions = (app: Express) => {
         resave: false, saveUninitialized: true,
         cookie: { 
             maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
-            sameSite: false, httpOnly: true, secure: false }
+            sameSite: false, httpOnly: true, secure: process.env.NODE_ENV === "production" }
     }));    
     app.use(lusca.csrf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/161](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/161)

To fix the problem, we need to make sure that the cookie is only transmitted over secure connections. The best way to do this is to set the cookie's `secure` attribute to `true`. This tells the browser to only send the cookie over HTTPS, not HTTP.  

Ideally, the value of `secure` should depend on the runtime environment:  
- In production (where HTTPS is used), it must be set to `true`.
- In development (where HTTPS may not be used), it may be set to `false` to avoid breaking local development.

We should update line 37 of the session configuration to set `secure: true`, or to dynamically select `secure: true` in production and `secure: false` in development, depending on an environment variable (`NODE_ENV`) or a value from configuration (`config`).  
If `config.secure` or an equivalent property exists, use it; otherwise, we can use `process.env.NODE_ENV`.  

We'll update the cookie configuration block in the `app.use(session({ ... }))` call to use a variable (`cookieSecure`) that is set to `true` in production, and to `false` otherwise. If you prefer, you can make this configurable via `config`, but based on the code snippet, using `process.env.NODE_ENV === "production"` is the safest generic choice.

No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
