### PR TITLE
Potential fix for code scanning alert no. 159: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter18/End_of_Chapter/sportsstore/src/sessions.ts
+++ b/Chapter18/End_of_Chapter/sportsstore/src/sessions.ts
@@ -32,7 +32,7 @@ export const createSessions = (app: Express) => {
         secret, store,
         resave: true, saveUninitialized: false,
         cookie: { maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
-            sameSite: "strict" }
+            sameSite: "strict", secure: true }
     }));
 
     app.use(csrf());


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/159](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/159)

To ensure the session cookie is only sent over HTTPS, add the `secure: true` property to the `cookie` object in the session middleware configuration. This change should be applied on line 35 within the `cookie` object passed to `session()`. This does not break existing functionality but strengthens security. If your deployment uses HTTP for development, you may want to make the setting conditional based on environment (not shown in the given code), but for maximum security, we set it to `true` per the recommendation.

No imports or new dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
