### PR TITLE
Potential fix for code scanning alert no. 162: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter20/Beginning_of_Chapter/sportsstore/src/sessions.ts
+++ b/Chapter20/Beginning_of_Chapter/sportsstore/src/sessions.ts
@@ -34,7 +34,7 @@ export const createSessions = (app: Express) => {
         resave: false, saveUninitialized: true,
         cookie: { 
             maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
-            sameSite: false, httpOnly: false, secure: false }
+            sameSite: false, httpOnly: process.env.NODE_ENV === "production", secure: process.env.NODE_ENV === "production" }
     }));    
     app.use(lusca.csrf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/162](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/162)

To fix the problem, we should ensure that the session cookie's `secure` attribute is set to `true` whenever the application is running under HTTPS (i.e., in production, or when the server expects HTTPS). Typically, this is done by basing the setting on an environment variable (such as `NODE_ENV`) or a configuration value. The `secure` setting should not be hard-coded to `false`.

The best fix is to edit the session middleware options in the `createSessions` function, such that the value of `cookie.secure` is set dynamically. If the application is running in production (often indicated by `NODE_ENV === "production"`, or a similar config), then `secure` should be `true`; otherwise, it may be `false` for developer convenience.

All changes should be confined to the file `Chapter20/Beginning_of_Chapter/sportsstore/src/sessions.ts`. If there is an existing configuration/environment variable that points to running in production, we should use that; otherwise, we can use `process.env.NODE_ENV`.

You may optionally also set other attributes (`httpOnly`, `sameSite`) securely, but the critical change is for `secure`. If possible, prefer making httpOnly `true` in production as well.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
