### PR TITLE
Potential fix for code scanning alert no. 160: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter19/Beginning_of_Chapter/sportsstore/src/sessions.ts
+++ b/Chapter19/Beginning_of_Chapter/sportsstore/src/sessions.ts
@@ -32,7 +32,8 @@ export const createSessions = (app: Express) => {
         secret, store,
         resave: true, saveUninitialized: false,
         cookie: { maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
-            sameSite: "strict" }
+            sameSite: "strict",
+            secure: true }
     }));
     app.use(lusca.csrf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/160](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/160)

To fix this issue, the `secure` attribute should be added (and set to `true`) in the cookie options when configuring the session middleware. This tells browsers to only send the cookie over HTTPS connections, preventing it from being transmitted in clear text over HTTP. The single best fix is to add `'secure': true` to the existing `cookie` configuration object inside the session middleware setup on line 34–35. This change should be made in `Chapter19/Beginning_of_Chapter/sportsstore/src/sessions.ts`.

There are no additional methods required, nor do we need to add imports. However, if you want to make this conditional (to support local development without HTTPS), you could use something like `process.env.NODE_ENV === 'production'` to set `secure: true` only in production, otherwise set it to `false`. For strict security, set `secure: true` unconditionally.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
