### PR TITLE
Potential fix for code scanning alert no. 158: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter18/Beginning_of_Chapter/sportsstore/src/sessions.ts
+++ b/Chapter18/Beginning_of_Chapter/sportsstore/src/sessions.ts
@@ -32,7 +32,7 @@ export const createSessions = (app: Express) => {
         secret, store,
         resave: true, saveUninitialized: false,
         cookie: { maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
-            sameSite: "strict" }
+            sameSite: "strict", secure: true }
     }));
     app.use(csrf());
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/158](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/158)

To fix the problem, ensure that the session cookie is always set with the `secure` attribute so it is only transmitted over HTTPS. The best practice is to set `cookie.secure: true` in the session configuration object. However, for development (non-HTTPS), this may pose a problem, so it's common to make this conditional based on the environment. But unless code or context specifies otherwise, the best fix is to add `secure: true` directly to the `cookie` object definition within the `session` middleware configuration. This change occurs on the single object starting on line 31 in `Chapter18/Beginning_of_Chapter/sportsstore/src/sessions.ts`.

**Steps and requirements:**
- Edit the `cookie` object in the session middleware configuration.
- Add `secure: true` to the `cookie` property’s object, ideally as the last setting for clarity.
- No new imports or major refactoring is necessary, as only the session config changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
