### PR TITLE
Potential fix for code scanning alert no. 137: Prototype-polluting function

### DIFF
--- a/Chapter16/sportsstore/src/config/merge.ts
+++ b/Chapter16/sportsstore/src/config/merge.ts
@@ -1,5 +1,9 @@
 export const merge = (target: any, source: any) : any => {
     Object.keys(source).forEach(key => {
+        // Prevent prototype pollution
+        if (key === "__proto__" || key === "constructor" || key === "prototype") {
+            return;
+        }
         if (typeof source[key] === "object" 
                 && !Array.isArray(source[key])) {
             if (Object.hasOwn(target, key)) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/137](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/137)

To fix the prototype pollution risk, the merge function should explicitly skip dangerous key names—those that could modify an object's prototype, such as `__proto__`, `constructor`, or `prototype`. The most straightforward and robust fix is to check inside the merge loop: if `key` is one of these dangerous property names, skip that key (`continue`). 

Specifically, add an early check inside the `forEach` callback (at the start or after line 2) to `return` early if `key` is `"__proto__"`, `"constructor"`, or `"prototype"`. This should be done for every key before any manipulation of `target[key]`, `Object.assign`, or recursive calls. No changes are needed to imports, as this logic is vanilla JavaScript/TypeScript.

Implementation steps:
- For every key in `source`, if the key equals `"__proto__"`, `"constructor"`, or `"prototype"`, skip processing.
- This change should be made in `Chapter16/sportsstore/src/config/merge.ts`, inside the `merge` function, before any access to `target[key]` or calls to `merge`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
