### PR TITLE
Potential fix for code scanning alert no. 144: Exposure of private files

### DIFF
--- a/Chapter19/Beginning_of_Chapter/sportsstore/src/server.ts
+++ b/Chapter19/Beginning_of_Chapter/sportsstore/src/server.ts
@@ -16,7 +16,7 @@ expressApp.use(express.json());
 expressApp.use(express.urlencoded({extended: true}))
 
 expressApp.use(express.static("node_modules/bootstrap/dist"));
-expressApp.use(express.static("node_modules/bootstrap-icons"));
+expressApp.use(express.static("node_modules/bootstrap-icons/font"));
 
 createTemplates(expressApp);
 createSessions(expressApp);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/144](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/144)

**General Fix:**  
Restrict static serving to only the subfolders (such as `font` or `icons`) or files that are actually needed for the frontend, rather than exposing the entire package directory. Only allow access to directories documented as public.

**Best Way to Fix:**  
Examine the `bootstrap-icons` package folder. Typically, the SVGs and distributable files are located in a folder like `node_modules/bootstrap-icons/font` or `node_modules/bootstrap-icons/icons`. Amend the `expressApp.use(express.static(...))` call (line 19) to *only* serve the needed subfolder.

**Specific Changes:**  
Edit line 19:  
- Replace `express.static("node_modules/bootstrap-icons")`  
- With: `express.static("node_modules/bootstrap-icons/font")` or `express.static("node_modules/bootstrap-icons/icons")` (depending on actual assets used by the app).  
(Assuming "font" is needed, as is common for Bootstrap Icons.)

No extra imports or methods are needed. Only the path argument to `express.static` changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
