### PR TITLE
Potential fix for code scanning alert no. 148: Exposure of private files

### DIFF
--- a/Chapter21/Beginning_of_Chapter/sportsstore/src/server.ts
+++ b/Chapter21/Beginning_of_Chapter/sportsstore/src/server.ts
@@ -18,7 +18,8 @@ expressApp.use(express.json());
 expressApp.use(express.urlencoded({extended: true}))
 
 expressApp.use(express.static("node_modules/bootstrap/dist"));
-expressApp.use(express.static("node_modules/bootstrap-icons"));
+// Only serve the 'icons' subdirectory from bootstrap-icons
+expressApp.use('/icons', express.static("node_modules/bootstrap-icons/icons"));
 expressApp.use(express.static("node_modules/htmx.org/dist"));
 
 createTemplates(expressApp);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/148](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/148)

**How to, in general terms, fix the problem:**  
Limit the static-serving middleware to only expose those files/folders within `bootstrap-icons` that are required by your application (likely the `icons` or `font` directory, or specific build artifacts). This approach restricts access to only necessary resources and mitigates the risk of exposing metadata or implementation details shipped with the npm package.

**Detailed single best fix:**  
Change the `express.static("node_modules/bootstrap-icons")` middleware to serve only the specific subdirectory (for example, `node_modules/bootstrap-icons/font`, `node_modules/bootstrap-icons/icons`, or similar) that contains the required static files used by your frontend. If you only use SVGs or fonts, serve just that path. If a subpath (like `font` or `icons`) is insufficient, consider explicitly copying needed files to a `public/` directory at build-time and serving from there.

**Specific edits needed:**  
- Edit line 21 in `Chapter21/Beginning_of_Chapter/sportsstore/src/server.ts` to restrict the exposed path based on what you actually need (e.g., `node_modules/bootstrap-icons/icons`).
- Ensure the server does not expose the entirety of the package root.
- No new method or import is required—just the path adjustment.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
