### PR TITLE
Potential fix for code scanning alert no. 147: Exposure of private files

### DIFF
--- a/Chapter20/End_of_Chapter/sportsstore/src/server.ts
+++ b/Chapter20/End_of_Chapter/sportsstore/src/server.ts
@@ -18,7 +18,7 @@ expressApp.use(express.json());
 expressApp.use(express.urlencoded({extended: true}))
 
 expressApp.use(express.static("node_modules/bootstrap/dist"));
-expressApp.use(express.static("node_modules/bootstrap-icons"));
+expressApp.use("/icons", express.static("node_modules/bootstrap-icons/icons"));
 expressApp.use(express.static("node_modules/htmx.org/dist"));
 
 createTemplates(expressApp);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/147](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/147)

To fix the issue, restrict the exposure of static files by only serving the required subfolder within `node_modules/bootstrap-icons`. Typically, only assets within the `icons` subdirectory are needed (e.g., SVGs) for frontend use. Thus, change the static serving line to expose only `node_modules/bootstrap-icons/icons`. Additionally, update the client-side asset references if they rely on the previous path.

Edit in `Chapter20/End_of_Chapter/sportsstore/src/server.ts`:  
- Replace the line serving the whole `bootstrap-icons` directory (line 21) with one serving only its `icons` subfolder.

No extra imports or major refactoring needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
