### PR TITLE
Potential fix for code scanning alert no. 152: Sensitive server cookie exposed to the client

### DIFF
--- a/Chapter21/End_of_Chapter/sportsstore/src/sessions.ts
+++ b/Chapter21/End_of_Chapter/sportsstore/src/sessions.ts
@@ -34,7 +34,7 @@ export const createSessions = (app: Express) => {
         resave: false, saveUninitialized: true,
         cookie: { 
             maxAge: config.maxAgeHrs * 60 * 60 * 1000, 
-            sameSite: false, httpOnly: false, secure: (process.env.NODE_ENV === 'production') }
+            sameSite: false, httpOnly: true, secure: (process.env.NODE_ENV === 'production') }
     }));
 
     app.use(csrf());


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/152](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/152)

To fix this vulnerability, set the `httpOnly` property to `true` in the cookie configuration for the session middleware. This ensures that cookies used for authentication/sessions cannot be accessed via client-side scripts, reducing the risk of session hijacking through XSS vulnerabilities.  
Specifically, in file `Chapter21/End_of_Chapter/sportsstore/src/sessions.ts`, update the `cookie` configuration object on line 37 to set `httpOnly: true`. No new methods or major refactoring are needed–just a simple configuration edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
