### PR TITLE
Potential fix for code scanning alert no. 149: Exposure of private files

### DIFF
--- a/Chapter21/End_of_Chapter/sportsstore/src/server.ts
+++ b/Chapter21/End_of_Chapter/sportsstore/src/server.ts
@@ -18,7 +18,7 @@ expressApp.use(express.json());
 expressApp.use(express.urlencoded({extended: true}))
 
 expressApp.use(express.static("node_modules/bootstrap/dist"));
-expressApp.use(express.static("node_modules/bootstrap-icons"));
+expressApp.use(express.static("node_modules/bootstrap-icons/icons"));
 expressApp.use(express.static("node_modules/htmx.org/dist"));
 
 createTemplates(expressApp);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/149](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/149)

To fix this issue, restrict static serving to only the assets within `node_modules/bootstrap-icons` that are actually needed by the client, rather than serving the entire package directory. Typically, for `bootstrap-icons`, you want to serve just the icons from `node_modules/bootstrap-icons/icons`. Therefore, you should change:
```ts
expressApp.use(express.static("node_modules/bootstrap-icons"));
```
to:
```ts
expressApp.use(express.static("node_modules/bootstrap-icons/icons"));
```
This serves only the distributable icons and avoids exposing other possible files in the package directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
