### PR TITLE
Potential fix for code scanning alert no. 146: Exposure of private files

### DIFF
--- a/Chapter20/Beginning_of_Chapter/sportsstore/src/server.ts
+++ b/Chapter20/Beginning_of_Chapter/sportsstore/src/server.ts
@@ -17,7 +17,7 @@ expressApp.use(express.json());
 expressApp.use(express.urlencoded({extended: true}))
 
 expressApp.use(express.static("node_modules/bootstrap/dist"));
-expressApp.use(express.static("node_modules/bootstrap-icons"));
+expressApp.use(express.static("node_modules/bootstrap-icons/icons"));
 
 createTemplates(expressApp);
 createSessions(expressApp);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/146](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/146)

To resolve the issue, restrict the static file serving to only those subfolders in `bootstrap-icons` that contain frontend assets required for your site (e.g., icons SVGs). Instead of serving the entire `node_modules/bootstrap-icons` folder, serve only the `icons` subfolder (or the specific asset subfolder you require). This limits risk and follows security best practices. You may need to adjust frontend code to reference new paths, but functionality remains the same. Update the `express.static` middleware on line 20 to serve only the needed subdirectory: `"node_modules/bootstrap-icons/icons"`. No new methods or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
