### PR TITLE
Potential fix for code scanning alert no. 179: Reflected cross-site scripting

### DIFF
--- a/Chapter15/End_of_Chapter/part2app/package.json
+++ b/Chapter15/End_of_Chapter/part2app/package.json
@@ -34,7 +34,8 @@
     "sequelize": "^6.35.1",
     "sqlite3": "^5.1.6",
     "validator": "^13.11.0",
-    "lusca": "^1.7.0"
+    "lusca": "^1.7.0",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.2",

--- a/Chapter15/End_of_Chapter/part2app/src/server/testHandler.ts
+++ b/Chapter15/End_of_Chapter/part2app/src/server/testHandler.ts
@@ -1,7 +1,25 @@
 import { Request, Response } from "express";
+import escapeHtml from "escape-html";
+
+function sanitize(input: any): any {
+    if (typeof input === "string") {
+        return escapeHtml(input);
+    } else if (Array.isArray(input)) {
+        return input.map(sanitize);
+    } else if (input && typeof input === "object") {
+        const sanitizedObj: any = {};
+        for (const key in input) {
+            if (Object.prototype.hasOwnProperty.call(input, key)) {
+                sanitizedObj[key] = sanitize(input[key]);
+            }
+        }
+        return sanitizedObj;
+    }
+    return input;
+}
 
 export const testHandler = async (req: Request, resp: Response) => {    
     resp.setHeader("Content-Type", "application/json")
-    resp.json(req.body);
+    resp.json(sanitize(req.body));
     resp.end();        
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/179](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/179)

To fix the problem, we need to ensure that user-supplied data in `req.body` is appropriately sanitized or encoded before being included in the HTTP response. This typically means applying contextual output encoding to every value destined for rendering, or (if possible) restricting output to safe keys/data only. Since the response is `application/json`, we can recursively escape any string values in the body using an HTML-escaping function to avoid dangerous content embedding. The best approach is to use a well-known library (such as `escape-html`) for escaping strings, and write a function that iterates over the body’s properties, recursively escaping all string fields before sending the sanitized object in the response. Only the code within Chapter15/End_of_Chapter/part2app/src/server/testHandler.ts needs editing: add the import for `escape-html`, define a recursive sanitize function, and use it on `req.body` before sending.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
