### PR TITLE
Potential fix for code scanning alert no. 178: Reflected cross-site scripting

### DIFF
--- a/Chapter15/Beginning_of_Chapter/part2app/package.json
+++ b/Chapter15/Beginning_of_Chapter/part2app/package.json
@@ -29,7 +29,8 @@
     "multer": "^2.0.2",
     "sequelize": "^6.35.1",
     "sqlite3": "^5.1.6",
-    "validator": "^13.11.0"
+    "validator": "^13.11.0",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.2",

--- a/Chapter15/Beginning_of_Chapter/part2app/src/server/testHandler.ts
+++ b/Chapter15/Beginning_of_Chapter/part2app/src/server/testHandler.ts
@@ -1,7 +1,28 @@
 import { Request, Response } from "express";
+import * as escapeHtml from "escape-html";
+
+
+// Recursively escape all string properties in an object/array
+function sanitizeInput(input: any): any {
+    if (typeof input === "string") {
+        return escapeHtml(input);
+    } else if (Array.isArray(input)) {
+        return input.map(sanitizeInput);
+    } else if (input && typeof input === "object") {
+        const sanitizedObj: any = {};
+        for (const key in input) {
+            if (input.hasOwnProperty(key)) {
+                sanitizedObj[key] = sanitizeInput(input[key]);
+            }
+        }
+        return sanitizedObj;
+    }
+    return input; // number, boolean, null, undefined
+}
 
 export const testHandler = async (req: Request, resp: Response) => {    
     resp.setHeader("Content-Type", "application/json")
-    resp.json(req.body);
+    const safeBody = sanitizeInput(req.body);
+    resp.json(safeBody);
     resp.end();        
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/178](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/178)

To mitigate reflected XSS, all user-controlled data (here, `req.body`) must be safely serialized and not allow injection of executable code or adversarial data. For JSON APIs, the risk is minimal when correctly using `resp.json()`, as it serializes data in a way that browsers don't execute. However, encoding characters that could start breakouts (e.g., `<`, `>`, `&`, `'`, `"`) in string values prevents risk in edge cases (such as misconfigured headers, old browsers, or clients that embed the response into HTML contexts).

The best practical fix is to recursively sanitize all string values in `req.body` before sending them back. This can be implemented by using a well-known escaping library like `escape-html` (for consistency with the recommendation) or manually encoding dangerous characters. Only string data in `req.body` need to be escaped, other data types can be left unchanged for API compatibility.

Required changes:
- Add the `escape-html` import at the top.
- Implement a sanitizer function to recursively traverse `req.body` and escape all string fields.
- Use the sanitized payload in `resp.json()`, instead of the raw `req.body`.
- Change only the `/src/server/testHandler.ts` file as provided.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
