### PR TITLE
Potential fix for code scanning alert no. 177: Reflected cross-site scripting

### DIFF
--- a/Chapter14/End_of_Chapter/part2app/package.json
+++ b/Chapter14/End_of_Chapter/part2app/package.json
@@ -30,7 +30,8 @@
     "sequelize": "^6.35.1",
     "sqlite3": "^5.1.6",
     "validator": "^13.11.0",
-    "lusca": "^1.7.0"
+    "lusca": "^1.7.0",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.2",

--- a/Chapter14/End_of_Chapter/part2app/src/server/testHandler.ts
+++ b/Chapter14/End_of_Chapter/part2app/src/server/testHandler.ts
@@ -1,7 +1,24 @@
 import { Request, Response } from "express";
+import escapeHtml from 'escape-html';
+// Recursively escapes all string fields in an object/array
+function escapeStrings(obj: any): any {
+    if (typeof obj === 'string') {
+        return escapeHtml(obj);
+    } else if (Array.isArray(obj)) {
+        return obj.map(escapeStrings);
+    } else if (obj && typeof obj === 'object') {
+        const sanitized: any = {};
+        for (const key of Object.keys(obj)) {
+            sanitized[key] = escapeStrings(obj[key]);
+        }
+        return sanitized;
+    }
+    return obj;
+}
 
 export const testHandler = async (req: Request, resp: Response) => {    
     resp.setHeader("Content-Type", "application/json")
-    resp.json(req.body);
+    const sanitizedBody = escapeStrings(req.body);
+    resp.json(sanitizedBody);
     resp.end();        
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/177](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/177)

To fix this vulnerability, sanitize all user-provided data before including it in the response, especially if any field is intended for HTML output on the client side. In a generic API endpoint returning JSON, you should escape potentially dangerous values in string fields. Use a well-tested library like `escape-html` to escape all string values inside `req.body` before calling `resp.json`. The best way is to recursively traverse `req.body`, escaping any string fields, and then return the sanitized object. Limit edits to this file as specified; add a helper for recursively escaping all string fields and require the `escape-html` library at the top.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
