### PR TITLE
Potential fix for code scanning alert no. 172: Reflected cross-site scripting

### DIFF
--- a/Chapter12/Beginning_of_Chapter/part2app/package.json
+++ b/Chapter12/Beginning_of_Chapter/part2app/package.json
@@ -19,7 +19,8 @@
     "helmet": "^8.1.0",
     "http-proxy": "^1.18.1",
     "multer": "^2.0.2",
-    "validator": "^13.15.15"
+    "validator": "^13.15.15",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/Chapter12/Beginning_of_Chapter/part2app/src/server/testHandler.ts
+++ b/Chapter12/Beginning_of_Chapter/part2app/src/server/testHandler.ts
@@ -1,7 +1,27 @@
 import { Request, Response } from "express";
+import escapeHtml from "escape-html";
+
+// Recursively escapes all string values in given obj/array
+function deepEscape(obj: any): any {
+    if (typeof obj === "string") {
+        return escapeHtml(obj);
+    } else if (Array.isArray(obj)) {
+        return obj.map(deepEscape);
+    } else if (obj && typeof obj === "object") {
+        const newObj: any = {};
+        for (const key in obj) {
+            if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                newObj[key] = deepEscape(obj[key]);
+            }
+        }
+        return newObj;
+    }
+    return obj;
+}
 
 export const testHandler = async (req: Request, resp: Response) => {    
     resp.setHeader("Content-Type", "application/json")
-    resp.json(req.body);
+    const sanitizedBody = deepEscape(req.body);
+    resp.json(sanitizedBody);
     resp.end();        
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/172](https://github.com/ibiscum/Mastering-Node.js-Web-Development/security/code-scanning/172)

To eliminate the potential XSS risk, all user-controlled values that are reflected back must be encoded or sanitized before including in the response. For JSON APIs, a defense-in-depth way is to recursively sanitize all string properties in `req.body` to escape dangerous characters (e.g., with a library like `lodash` for traversal and `escape-html` for escaping, or by custom-encoding only string fields). The best, simplest, and smallest change—while not changing the general output/formatting—is to traverse the `req.body` and escape any strings using a well-known HTML escape module before returning.

**Changes required:**
1. Add an import for `escape-html`.
2. Write a utility to recursively escape string values in an object.
3. Apply this sanitization to `req.body` before calling `resp.json`.
4. Leave headers and general functionality untouched.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
